### PR TITLE
Multiple governances

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -8,6 +8,9 @@ pub enum PaladinGovernanceError {
     /// Stake config accounts mismatch.
     #[error("Stake config accounts mismatch.")]
     StakeConfigMismatch,
+    /// Incorrect stake config.
+    #[error("Incorrect stake config.")]
+    IncorrectStakeConfig,
     /// Incorrect proposal vote address.
     #[error("Incorrect proposal vote address.")]
     IncorrectProposalVoteAddress,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -149,9 +149,6 @@ pub enum PaladinGovernanceInstruction {
         /// The minimum required threshold of proposal rejection to terminate
         /// the proposal.
         proposal_rejection_threshold: u64,
-        /// The Paladin stake config account that this governance config account
-        /// corresponds to.
-        stake_config_address: Pubkey,
     },
 }
 
@@ -191,13 +188,11 @@ impl PaladinGovernanceInstruction {
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
-                stake_config_address,
             } => {
                 let mut buf = vec![6];
                 buf.extend_from_slice(&cooldown_period_seconds.to_le_bytes());
                 buf.extend_from_slice(&proposal_acceptance_threshold.to_le_bytes());
                 buf.extend_from_slice(&proposal_rejection_threshold.to_le_bytes());
-                buf.extend_from_slice(stake_config_address.as_ref());
                 buf
             }
         }
@@ -228,18 +223,16 @@ impl PaladinGovernanceInstruction {
                     stake_config_address,
                 })
             }
-            Some((&6, rest)) if rest.len() == 56 => {
+            Some((&6, rest)) if rest.len() == 24 => {
                 let cooldown_period_seconds = u64::from_le_bytes(rest[..8].try_into().unwrap());
                 let proposal_acceptance_threshold =
                     u64::from_le_bytes(rest[8..16].try_into().unwrap());
                 let proposal_rejection_threshold =
                     u64::from_le_bytes(rest[16..24].try_into().unwrap());
-                let stake_config_address = Pubkey::new_from_array(rest[24..56].try_into().unwrap());
                 Ok(Self::UpdateGovernance {
                     cooldown_period_seconds,
                     proposal_acceptance_threshold,
                     proposal_rejection_threshold,
-                    stake_config_address,
                 })
             }
             _ => Err(ProgramError::InvalidInstructionData),
@@ -373,7 +366,6 @@ pub fn update_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
-    stake_config_address: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*governance_config_address, false),
@@ -383,7 +375,6 @@ pub fn update_governance(
         cooldown_period_seconds,
         proposal_acceptance_threshold,
         proposal_rejection_threshold,
-        stake_config_address: *stake_config_address,
     }
     .pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)
@@ -442,7 +433,6 @@ mod tests {
             cooldown_period_seconds: 1,
             proposal_acceptance_threshold: 2,
             proposal_rejection_threshold: 3,
-            stake_config_address: Pubkey::new_unique(),
         });
     }
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -109,7 +109,8 @@ pub enum PaladinGovernanceInstruction {
     /// Accounts expected by this instruction:
     ///
     /// 0. `[w]` Governance config account.
-    /// 1. `[ ]` System program.
+    /// 1. `[ ]` Paladin stake config account.
+    /// 2. `[ ]` System program.
     InitializeGovernance {
         /// The cooldown period that begins when a proposal reaches the
         /// `proposal_acceptance_threshold` and upon its conclusion will execute
@@ -121,9 +122,6 @@ pub enum PaladinGovernanceInstruction {
         /// The minimum required threshold of proposal rejection to terminate
         /// the proposal.
         proposal_rejection_threshold: u64,
-        /// The Paladin stake config account that this governance config account
-        /// corresponds to.
-        stake_config_address: Pubkey,
     },
     /// Update the governance config.
     ///
@@ -175,13 +173,11 @@ impl PaladinGovernanceInstruction {
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
-                stake_config_address,
             } => {
                 let mut buf = vec![5];
                 buf.extend_from_slice(&cooldown_period_seconds.to_le_bytes());
                 buf.extend_from_slice(&proposal_acceptance_threshold.to_le_bytes());
                 buf.extend_from_slice(&proposal_rejection_threshold.to_le_bytes());
-                buf.extend_from_slice(stake_config_address.as_ref());
                 buf
             }
             Self::UpdateGovernance {
@@ -209,18 +205,16 @@ impl PaladinGovernanceInstruction {
                 new_vote: rest[0] == 1,
             }),
             Some((&4, _)) => Ok(Self::ProcessProposal),
-            Some((&5, rest)) if rest.len() == 56 => {
+            Some((&5, rest)) if rest.len() == 24 => {
                 let cooldown_period_seconds = u64::from_le_bytes(rest[..8].try_into().unwrap());
                 let proposal_acceptance_threshold =
                     u64::from_le_bytes(rest[8..16].try_into().unwrap());
                 let proposal_rejection_threshold =
                     u64::from_le_bytes(rest[16..24].try_into().unwrap());
-                let stake_config_address = Pubkey::new_from_array(rest[24..56].try_into().unwrap());
                 Ok(Self::InitializeGovernance {
                     cooldown_period_seconds,
                     proposal_acceptance_threshold,
                     proposal_rejection_threshold,
-                    stake_config_address,
                 })
             }
             Some((&6, rest)) if rest.len() == 24 => {
@@ -338,20 +332,20 @@ pub fn process_proposal(
 /// instruction.
 pub fn initialize_governance(
     governance_config_address: &Pubkey,
+    stake_config_address: &Pubkey,
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
-    stake_config_address: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*governance_config_address, false),
+        AccountMeta::new_readonly(*stake_config_address, false),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
     let data = PaladinGovernanceInstruction::InitializeGovernance {
         cooldown_period_seconds,
         proposal_acceptance_threshold,
         proposal_rejection_threshold,
-        stake_config_address: *stake_config_address,
     }
     .pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)
@@ -423,7 +417,6 @@ mod tests {
             cooldown_period_seconds: 1,
             proposal_acceptance_threshold: 2,
             proposal_rejection_threshold: 3,
-            stake_config_address: Pubkey::new_unique(),
         });
     }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -555,6 +555,7 @@ fn process_initialize_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
+    stake_config_address: Pubkey,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -600,6 +601,7 @@ fn process_initialize_governance(
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
+                stake_config_address,
             };
     }
 
@@ -615,6 +617,7 @@ fn process_update_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
+    stake_config_address: Pubkey,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -657,6 +660,7 @@ fn process_update_governance(
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
+            stake_config_address,
         };
 
     Ok(())
@@ -691,6 +695,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
+            stake_config_address,
         } => {
             msg!("Instruction: InitializeGovernance");
             process_initialize_governance(
@@ -699,12 +704,14 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
+                stake_config_address,
             )
         }
         PaladinGovernanceInstruction::UpdateGovernance {
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
+            stake_config_address,
         } => {
             msg!("Instruction: UpdateGovernance");
             process_update_governance(
@@ -713,6 +720,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
+                stake_config_address,
             )
         }
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -619,7 +619,6 @@ fn process_update_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
-    stake_config_address: Pubkey,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -651,13 +650,11 @@ fn process_update_governance(
 
     // Update the governance config.
     let mut data = governance_info.try_borrow_mut_data()?;
-    *bytemuck::try_from_bytes_mut(&mut data).map_err(|_| ProgramError::InvalidAccountData)? =
-        Config {
-            cooldown_period_seconds,
-            proposal_acceptance_threshold,
-            proposal_rejection_threshold,
-            stake_config_address,
-        };
+    let state = bytemuck::try_from_bytes_mut::<Config>(&mut data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+    state.cooldown_period_seconds = cooldown_period_seconds;
+    state.proposal_acceptance_threshold = proposal_acceptance_threshold;
+    state.proposal_rejection_threshold = proposal_rejection_threshold;
 
     Ok(())
 }
@@ -707,7 +704,6 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
-            stake_config_address,
         } => {
             msg!("Instruction: UpdateGovernance");
             process_update_governance(
@@ -716,7 +712,6 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
-                stake_config_address,
             )
         }
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -269,7 +269,10 @@ fn process_vote(program_id: &Pubkey, accounts: &[AccountInfo], vote: bool) -> Pr
 
     // Ensure the provided governance address is the correct address derived from
     // the program.
-    if !governance_info.key.eq(&get_governance_address(program_id)) {
+    if !governance_info
+        .key
+        .eq(&get_governance_address(stake_config_info.key, program_id))
+    {
         return Err(PaladinGovernanceError::IncorrectGovernanceConfigAddress.into());
     }
 
@@ -390,7 +393,10 @@ fn process_switch_vote(
 
     // Ensure the provided governance address is the correct address derived from
     // the program.
-    if !governance_info.key.eq(&get_governance_address(program_id)) {
+    if !governance_info
+        .key
+        .eq(&get_governance_address(stake_config_info.key, program_id))
+    {
         return Err(PaladinGovernanceError::IncorrectGovernanceConfigAddress.into());
     }
 
@@ -514,12 +520,6 @@ fn process_process_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pr
     // then drop this account.
     let governance_info = next_account_info(accounts_iter)?;
 
-    // Ensure the provided governance address is the correct address derived from
-    // the program.
-    if !governance_info.key.eq(&get_governance_address(program_id)) {
-        return Err(PaladinGovernanceError::IncorrectGovernanceConfigAddress.into());
-    }
-
     check_governance_exists(program_id, governance_info)?;
     check_proposal_exists(program_id, proposal_info)?;
 
@@ -564,9 +564,11 @@ fn process_initialize_governance(
 
     // Create the governance config account.
     {
-        let (governance_address, bump_seed) = get_governance_address_and_bump_seed(program_id);
+        let (governance_address, bump_seed) =
+            get_governance_address_and_bump_seed(&stake_config_address, program_id);
         let bump_seed = [bump_seed];
-        let governance_signer_seeds = collect_governance_signer_seeds(&bump_seed);
+        let governance_signer_seeds =
+            collect_governance_signer_seeds(&stake_config_address, &bump_seed);
 
         // Ensure the provided governance address is the correct address
         // derived from the program.
@@ -625,12 +627,6 @@ fn process_update_governance(
     let proposal_info = next_account_info(accounts_iter)?;
     // Same note as `process_process_proposal` applies here for cutting
     // the stake config account.
-
-    // Ensure the provided governance address is the correct address derived from
-    // the program.
-    if !governance_info.key.eq(&get_governance_address(program_id)) {
-        return Err(PaladinGovernanceError::IncorrectGovernanceConfigAddress.into());
-    }
 
     check_governance_exists(program_id, governance_info)?;
     check_proposal_exists(program_id, proposal_info)?;

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -140,6 +140,16 @@ pub struct Config {
     pub stake_config_address: Pubkey,
 }
 
+impl Config {
+    /// Evaluate a provided address against the corresponding stake config.
+    pub fn check_stake_config(&self, stake_config: &Pubkey) -> ProgramResult {
+        if self.stake_config_address == *stake_config {
+            return Ok(());
+        }
+        Err(PaladinGovernanceError::IncorrectStakeConfig.into())
+    }
+}
+
 /// Governance proposal account.
 #[derive(Clone, Copy, Debug, PartialEq, Pod, SplDiscriminate, Zeroable)]
 #[discriminator_hash_input("governance::state::proposal")]

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -13,11 +13,11 @@ use {
 
 /// The seed prefix (`"piggy_bank"`) in bytes used to derive the address of the
 /// treasury account.
-/// Seeds: `"piggy_bank"`.
+/// Seeds: `"piggy_bank" + stake_config_address`.
 pub const SEED_PREFIX_TREASURY: &[u8] = b"piggy_bank";
 /// The seed prefix (`"governance"`) in bytes used to derive the address of the
 /// governance config account.
-/// Seeds: `"governance"`.
+/// Seeds: `"governance" + stake_config_address`.
 pub const SEED_PREFIX_GOVERNANCE: &[u8] = b"governance";
 /// The seed prefix (`"proposal_vote"`) in bytes used to derive the address of
 /// the proposal vote account, representing a vote cast by a validator for a
@@ -26,35 +26,48 @@ pub const SEED_PREFIX_GOVERNANCE: &[u8] = b"governance";
 pub const SEED_PREFIX_PROPOSAL_VOTE: &[u8] = b"proposal_vote";
 
 /// Derive the address of the treasury account.
-pub fn get_treasury_address(program_id: &Pubkey) -> Pubkey {
-    get_treasury_address_and_bump_seed(program_id).0
+pub fn get_treasury_address(stake_config_address: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    get_treasury_address_and_bump_seed(stake_config_address, program_id).0
 }
 
 /// Derive the address of the treasury account, with bump seed.
-pub fn get_treasury_address_and_bump_seed(program_id: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&collect_treasury_seeds(), program_id)
+pub fn get_treasury_address_and_bump_seed(
+    stake_config_address: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&collect_treasury_seeds(stake_config_address), program_id)
 }
 
-pub(crate) fn collect_treasury_seeds<'a>() -> [&'a [u8]; 1] {
-    [SEED_PREFIX_TREASURY]
+pub(crate) fn collect_treasury_seeds(stake_config_address: &Pubkey) -> [&[u8]; 2] {
+    [SEED_PREFIX_TREASURY, stake_config_address.as_ref()]
 }
 
 /// Derive the address of the governance config account.
-pub fn get_governance_address(program_id: &Pubkey) -> Pubkey {
-    get_governance_address_and_bump_seed(program_id).0
+pub fn get_governance_address(stake_config_address: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    get_governance_address_and_bump_seed(stake_config_address, program_id).0
 }
 
 /// Derive the address of the governance config account, with bump seed.
-pub fn get_governance_address_and_bump_seed(program_id: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&collect_governance_seeds(), program_id)
+pub fn get_governance_address_and_bump_seed(
+    stake_config_address: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&collect_governance_seeds(stake_config_address), program_id)
 }
 
-pub(crate) fn collect_governance_seeds<'a>() -> [&'a [u8]; 1] {
-    [SEED_PREFIX_GOVERNANCE]
+pub(crate) fn collect_governance_seeds(stake_config_address: &Pubkey) -> [&[u8]; 2] {
+    [SEED_PREFIX_GOVERNANCE, stake_config_address.as_ref()]
 }
 
-pub(crate) fn collect_governance_signer_seeds(bump_seed: &[u8]) -> [&[u8]; 2] {
-    [SEED_PREFIX_GOVERNANCE, bump_seed]
+pub(crate) fn collect_governance_signer_seeds<'a>(
+    stake_config_address: &'a Pubkey,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 3] {
+    [
+        SEED_PREFIX_GOVERNANCE,
+        stake_config_address.as_ref(),
+        bump_seed,
+    ]
 }
 
 /// Derive the address of a proposal vote account.

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -122,9 +122,9 @@ pub struct Config {
     /// Stored as a `u64`, which includes a scaling factor of `1e9` to
     /// represent the threshold with 9 decimal places of precision.
     pub proposal_rejection_threshold: u64,
-    // TODO: We may need to store the stake config account, so we can check
-    // that a provide stake config account is the correct one for the
-    // particular governance config a proposal is using.
+    /// The Paladin stake config account that this governance config account
+    /// corresponds to.
+    pub stake_config_address: Pubkey,
 }
 
 /// Governance proposal account.

--- a/program/tests/initialize_governance.rs
+++ b/program/tests/initialize_governance.rs
@@ -31,6 +31,7 @@ async fn fail_governance_incorrect_address() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -62,16 +63,19 @@ async fn fail_governance_incorrect_address() {
 async fn fail_governance_already_initialized() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
+    let stake_config_address = Pubkey::new_unique();
+
     let mut context = setup().start_with_context().await;
 
     // Set up an already initialized governance account.
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address).await;
 
     let instruction = initialize_governance(
         &governance,
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        &stake_config_address,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -98,6 +102,8 @@ async fn fail_governance_already_initialized() {
 async fn success() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
+    let stake_config_address = Pubkey::new_unique();
+
     let mut context = setup().start_with_context().await;
 
     // Fund the governance account.
@@ -115,6 +121,7 @@ async fn success() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        &stake_config_address,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -143,6 +150,7 @@ async fn success() {
             cooldown_period_seconds: 0,
             proposal_acceptance_threshold: 0,
             proposal_rejection_threshold: 0,
+            stake_config_address
         }
     );
 }

--- a/program/tests/initialize_governance.rs
+++ b/program/tests/initialize_governance.rs
@@ -61,9 +61,9 @@ async fn fail_governance_incorrect_address() {
 
 #[tokio::test]
 async fn fail_governance_already_initialized() {
-    let governance = get_governance_address(&paladin_governance_program::id());
-
     let stake_config_address = Pubkey::new_unique();
+    let governance =
+        get_governance_address(&stake_config_address, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -100,9 +100,9 @@ async fn fail_governance_already_initialized() {
 
 #[tokio::test]
 async fn success() {
-    let governance = get_governance_address(&paladin_governance_program::id());
-
     let stake_config_address = Pubkey::new_unique();
+    let governance =
+        get_governance_address(&stake_config_address, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::process_proposal,
-        state::{get_governance_address, Config, Proposal},
+        state::{Config, Proposal},
     },
     setup::{setup, setup_governance, setup_proposal_with_stake_and_cooldown},
     solana_program_test::*,
@@ -22,43 +22,9 @@ use {
 };
 
 #[tokio::test]
-async fn fail_governance_incorrect_address() {
-    let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // Incorrect governance address.
-
-    let mut context = setup().start_with_context().await;
-
-    let instruction = process_proposal(&proposal, &governance);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(
-                PaladinGovernanceError::IncorrectGovernanceConfigAddress as u32
-            )
-        )
-    );
-}
-
-#[tokio::test]
 async fn fail_governance_incorrect_owner() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -98,7 +64,7 @@ async fn fail_governance_incorrect_owner() {
 #[tokio::test]
 async fn fail_governance_not_initialized() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -137,7 +103,7 @@ async fn fail_governance_not_initialized() {
 #[tokio::test]
 async fn fail_proposal_incorrect_owner() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(
@@ -186,7 +152,7 @@ async fn fail_proposal_incorrect_owner() {
 #[tokio::test]
 async fn fail_proposal_not_initialized() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(
@@ -235,7 +201,7 @@ async fn fail_proposal_not_initialized() {
 #[tokio::test]
 async fn fail_proposal_not_accepted() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -292,7 +258,7 @@ async fn fail_proposal_not_accepted() {
 #[tokio::test]
 async fn success() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -140,7 +140,15 @@ async fn fail_proposal_incorrect_owner() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+    )
+    .await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -181,7 +189,15 @@ async fn fail_proposal_not_initialized() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+    )
+    .await;
 
     // Set up the proposal account uninitialized.
     {
@@ -226,7 +242,15 @@ async fn fail_proposal_not_accepted() {
     // Set up an unaccepted proposal.
     // Simply set the cooldown timestamp to the current clock timestamp,
     // and require more than 0 seconds for cooldown.
-    setup_governance(&mut context, &governance, 1_000_000, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        1_000_000,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+    )
+    .await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     setup_proposal_with_stake_and_cooldown(
         &mut context,
@@ -271,7 +295,15 @@ async fn success() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+    )
+    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -76,11 +76,13 @@ pub async fn setup_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u64,
     proposal_rejection_threshold: u64,
+    stake_config_address: &Pubkey,
 ) {
     let state = Config {
         cooldown_period_seconds,
         proposal_acceptance_threshold,
         proposal_rejection_threshold,
+        stake_config_address: *stake_config_address,
     };
     let data = bytemuck::bytes_of(&state).to_vec();
 

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -37,7 +37,7 @@ async fn fail_stake_authority_not_signer() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -82,7 +82,7 @@ async fn fail_stake_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -137,7 +137,7 @@ async fn fail_stake_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -192,7 +192,7 @@ async fn fail_stake_incorrect_stake_authority() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -246,7 +246,7 @@ async fn fail_stake_config_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake(
@@ -310,7 +310,7 @@ async fn fail_stake_config_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake(
@@ -433,7 +433,7 @@ async fn fail_governance_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -497,7 +497,7 @@ async fn fail_governance_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -560,7 +560,7 @@ async fn fail_proposal_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -625,7 +625,7 @@ async fn fail_proposal_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -689,7 +689,7 @@ async fn fail_proposal_vote_incorrect_address() {
 
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote = Pubkey::new_unique(); // Incorrect proposal vote address.
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -747,7 +747,7 @@ async fn fail_proposal_vote_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -962,7 +962,7 @@ async fn success(proposal_setup: ProposalSetup, vote_test: SwitchVoteTest) {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, total_stake).await;

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -572,7 +572,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -637,7 +637,7 @@ async fn fail_proposal_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
 
     // Set up the proposal account uninitialized.
     {
@@ -701,7 +701,7 @@ async fn fail_proposal_vote_incorrect_address() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
     setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
 
     let instruction = paladin_governance_program::instruction::switch_vote(
@@ -759,7 +759,7 @@ async fn fail_proposal_vote_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
     setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
 
     // Set up an uninitialized proposal vote account.
@@ -980,6 +980,7 @@ async fn success(proposal_setup: ProposalSetup, vote_test: SwitchVoteTest) {
         /* cooldown_period_seconds */ 10, // Unused here.
         acceptance_threshold,
         rejection_threshold,
+        &stake_config,
     )
     .await;
 

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -34,6 +34,7 @@ async fn fail_governance_incorrect_address() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -85,6 +86,7 @@ async fn fail_governance_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -130,6 +132,7 @@ async fn fail_governance_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -158,7 +161,15 @@ async fn fail_proposal_incorrect_owner() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(),
+    )
+    .await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -177,6 +188,7 @@ async fn fail_proposal_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -205,7 +217,15 @@ async fn fail_proposal_not_initialized() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(),
+    )
+    .await;
 
     // Set up the proposal account uninitialized.
     {
@@ -224,6 +244,7 @@ async fn fail_proposal_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -256,7 +277,15 @@ async fn fail_proposal_not_accepted() {
     // Set up an unaccepted proposal.
     // Simply set the cooldown timestamp to the current clock timestamp,
     // and require more than 0 seconds for cooldown.
-    setup_governance(&mut context, &governance, 1_000_000, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        1_000_000,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(),
+    )
+    .await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     setup_proposal_with_stake_and_cooldown(
         &mut context,
@@ -276,6 +305,7 @@ async fn fail_proposal_not_accepted() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -307,7 +337,15 @@ async fn success() {
     let governance = get_governance_address(&paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(),
+    )
+    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -320,12 +358,15 @@ async fn success() {
     )
     .await;
 
+    let new_stake_config_address = Pubkey::new_unique();
+
     let instruction = update_governance(
         &governance,
         &proposal,
         /* cooldown_period_seconds */ 1,
         /* proposal_acceptance_threshold */ 2,
         /* proposal_rejection_threshold */ 3,
+        &new_stake_config_address,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -354,6 +395,7 @@ async fn success() {
             cooldown_period_seconds: 1,
             proposal_acceptance_threshold: 2,
             proposal_rejection_threshold: 3,
+            stake_config_address: new_stake_config_address,
         }
     );
 }

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -45,7 +45,6 @@ async fn fail_governance_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -91,7 +90,6 @@ async fn fail_governance_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -147,7 +145,6 @@ async fn fail_proposal_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -203,7 +200,6 @@ async fn fail_proposal_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -264,7 +260,6 @@ async fn fail_proposal_not_accepted() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -295,16 +290,10 @@ async fn success() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let stake_config_address = Pubkey::new_unique();
+
     let mut context = setup().start_with_context().await;
-    setup_governance(
-        &mut context,
-        &governance,
-        0,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(),
-    )
-    .await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address).await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -317,15 +306,12 @@ async fn success() {
     )
     .await;
 
-    let new_stake_config_address = Pubkey::new_unique();
-
     let instruction = update_governance(
         &governance,
         &proposal,
         /* cooldown_period_seconds */ 1,
         /* proposal_acceptance_threshold */ 2,
         /* proposal_rejection_threshold */ 3,
-        &new_stake_config_address,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -354,7 +340,7 @@ async fn success() {
             cooldown_period_seconds: 1,
             proposal_acceptance_threshold: 2,
             proposal_rejection_threshold: 3,
-            stake_config_address: new_stake_config_address,
+            stake_config_address,
         }
     );
 }

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::update_governance,
-        state::{get_governance_address, Config, Proposal},
+        state::{Config, Proposal},
     },
     setup::{setup, setup_governance, setup_proposal_with_stake_and_cooldown},
     solana_program_test::*,
@@ -22,50 +22,9 @@ use {
 };
 
 #[tokio::test]
-async fn fail_governance_incorrect_address() {
-    let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // Incorrect governance address.
-
-    let mut context = setup().start_with_context().await;
-
-    let instruction = update_governance(
-        &governance,
-        &proposal,
-        /* cooldown_period_seconds */ 0,
-        /* proposal_acceptance_threshold */ 0,
-        /* proposal_rejection_threshold */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(),
-    );
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(
-                PaladinGovernanceError::IncorrectGovernanceConfigAddress as u32
-            )
-        )
-    );
-}
-
-#[tokio::test]
 async fn fail_governance_incorrect_owner() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -112,7 +71,7 @@ async fn fail_governance_incorrect_owner() {
 #[tokio::test]
 async fn fail_governance_not_initialized() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -158,7 +117,7 @@ async fn fail_governance_not_initialized() {
 #[tokio::test]
 async fn fail_proposal_incorrect_owner() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(
@@ -214,7 +173,7 @@ async fn fail_proposal_incorrect_owner() {
 #[tokio::test]
 async fn fail_proposal_not_initialized() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(
@@ -270,7 +229,7 @@ async fn fail_proposal_not_initialized() {
 #[tokio::test]
 async fn fail_proposal_not_accepted() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
 
@@ -334,7 +293,7 @@ async fn fail_proposal_not_accepted() {
 #[tokio::test]
 async fn success() {
     let proposal = Pubkey::new_unique();
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
     setup_governance(

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -37,7 +37,7 @@ async fn fail_stake_authority_not_signer() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -82,7 +82,7 @@ async fn fail_stake_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -137,7 +137,7 @@ async fn fail_stake_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -192,7 +192,7 @@ async fn fail_stake_incorrect_stake_authority() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -246,7 +246,7 @@ async fn fail_stake_config_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake(
@@ -310,7 +310,7 @@ async fn fail_stake_config_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake(
@@ -433,7 +433,7 @@ async fn fail_governance_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -497,7 +497,7 @@ async fn fail_governance_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -560,7 +560,7 @@ async fn fail_proposal_incorrect_owner() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -625,7 +625,7 @@ async fn fail_proposal_not_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -689,7 +689,7 @@ async fn fail_proposal_vote_incorrect_address() {
 
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote = Pubkey::new_unique(); // Incorrect proposal vote address.
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -747,7 +747,7 @@ async fn fail_proposal_vote_already_initialized() {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, 0).await;
@@ -949,7 +949,7 @@ async fn success(proposal_setup: ProposalSetup, vote_test: VoteTest) {
     let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
     let proposal_vote =
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
-    let governance = get_governance_address(&paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_stake_config(&mut context, &stake_config, total_stake).await;

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -572,7 +572,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -637,7 +637,7 @@ async fn fail_proposal_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
 
     // Set up the proposal account uninitialized.
     {
@@ -701,7 +701,7 @@ async fn fail_proposal_vote_incorrect_address() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
     setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
 
     let instruction = paladin_governance_program::instruction::vote(
@@ -759,7 +759,7 @@ async fn fail_proposal_vote_already_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
     setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
 
     // Set up an initialized proposal vote account.
@@ -967,6 +967,7 @@ async fn success(proposal_setup: ProposalSetup, vote_test: VoteTest) {
         /* cooldown_period_seconds */ 10, // Unused here.
         acceptance_threshold,
         rejection_threshold,
+        &stake_config,
     )
     .await;
     setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;


### PR DESCRIPTION
This PR adds support for multiple governance configs, each of
which correspond to stake configs, as suggested in #7.