### PR TITLE
State machine

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -17,6 +17,12 @@ pub enum PaladinGovernanceError {
     /// Incorrect governance config address.
     #[error("Incorrect governance config address.")]
     IncorrectGovernanceConfigAddress,
+    /// Proposal not in voting stage.
+    #[error("Proposal not in voting stage.")]
+    ProposalNotInVotingStage,
+    /// Proposal is immutable.
+    #[error("Proposal is immutable.")]
+    ProposalIsImmutable,
     /// Proposal not accepted.
     #[error("Proposal not accepted.")]
     ProposalNotAccepted,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -218,10 +218,14 @@ fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     proposal_state.check_author(stake_authority_info.key)?;
 
     // Ensure the proposal is in draft or voting stage.
-    if proposal_state.status != ProposalStatus::Draft
-        && proposal_state.status != ProposalStatus::Voting
-    {
-        return Err(PaladinGovernanceError::ProposalIsImmutable.into());
+    match proposal_state.status {
+        ProposalStatus::Draft | ProposalStatus::Voting => (),
+        ProposalStatus::Cancelled
+        | ProposalStatus::Accepted
+        | ProposalStatus::Rejected
+        | ProposalStatus::Processed => {
+            return Err(PaladinGovernanceError::ProposalIsImmutable.into())
+        }
     }
 
     // Set the proposal's status to cancelled.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -231,9 +231,9 @@ fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
 }
 
 /// Processes a
-/// [FinalizeProposal](enum.PaladinGovernanceInstruction.html)
+/// [BeginVoting](enum.PaladinGovernanceInstruction.html)
 /// instruction.
-fn process_finalize_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+fn process_begin_voting(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
     let stake_authority_info = next_account_info(accounts_iter)?;
@@ -747,9 +747,9 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             msg!("Instruction: CancelProposal");
             process_cancel_proposal(program_id, accounts)
         }
-        PaladinGovernanceInstruction::FinalizeProposal => {
-            msg!("Instruction: FinalizeProposal");
-            process_finalize_proposal(program_id, accounts)
+        PaladinGovernanceInstruction::BeginVoting => {
+            msg!("Instruction: BeginVoting");
+            process_begin_voting(program_id, accounts)
         }
         PaladinGovernanceInstruction::Vote { election } => {
             msg!("Instruction: Vote");

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -175,6 +175,27 @@ impl Config {
     }
 }
 
+/// The status of a governance proposal.
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ProposalStatus {
+    /// The proposal is in the draft stage.
+    Draft,
+    /// The proposal is in the voting stage.
+    Voting,
+    /// The proposal was cancelled.
+    Cancelled,
+    /// The proposal was accepted.
+    Accepted,
+    /// The proposal was rejected.
+    Rejected,
+    /// The proposal was accepted and processed.
+    Processed,
+}
+
+unsafe impl Pod for ProposalStatus {}
+unsafe impl Zeroable for ProposalStatus {}
+
 /// Governance proposal account.
 #[derive(Clone, Copy, Debug, PartialEq, Pod, SplDiscriminate, Zeroable)]
 #[discriminator_hash_input("governance::state::proposal")]
@@ -197,6 +218,9 @@ pub struct Proposal {
     pub stake_against: u64,
     /// Amount of stake in favor of the proposal.
     pub stake_for: u64,
+    /// Proposal status
+    pub status: ProposalStatus,
+    _padding: [u8; 7],
 }
 
 impl Proposal {
@@ -211,6 +235,8 @@ impl Proposal {
             stake_abstained: 0,
             stake_against: 0,
             stake_for: 0,
+            status: ProposalStatus::Draft,
+            _padding: [0; 7],
         }
     }
 

--- a/program/tests/begin_voting.rs
+++ b/program/tests/begin_voting.rs
@@ -4,7 +4,7 @@ mod setup;
 
 use {
     paladin_governance_program::{
-        instruction::finalize_proposal,
+        instruction::begin_voting,
         state::{Proposal, ProposalStatus},
     },
     setup::{setup, setup_proposal},
@@ -26,7 +26,7 @@ async fn fail_stake_authority_not_signer() {
 
     let mut context = setup().start_with_context().await;
 
-    let mut instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    let mut instruction = begin_voting(&stake_authority.pubkey(), &proposal);
     instruction.accounts[0].is_signer = false; // Stake authority not signer.
 
     let transaction = Transaction::new_signed_with_payer(
@@ -67,7 +67,7 @@ async fn fail_proposal_incorrect_owner() {
         );
     }
 
-    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    let instruction = begin_voting(&stake_authority.pubkey(), &proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -107,7 +107,7 @@ async fn fail_proposal_not_initialized() {
         );
     }
 
-    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    let instruction = begin_voting(&stake_authority.pubkey(), &proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -145,7 +145,7 @@ async fn fail_stake_authority_not_author() {
     )
     .await;
 
-    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    let instruction = begin_voting(&stake_authority.pubkey(), &proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -183,7 +183,7 @@ async fn success() {
     )
     .await;
 
-    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    let instruction = begin_voting(&stake_authority.pubkey(), &proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],

--- a/program/tests/cancel_proposal.rs
+++ b/program/tests/cancel_proposal.rs
@@ -240,13 +240,13 @@ async fn success() {
         .await
         .unwrap();
 
-    // Assert the proposal was cleared and reassigned to the system program.
+    // Assert the proposal was marked with cancelled status.
     let proposal_account = context
         .banks_client
         .get_account(proposal)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(proposal_account.owner, solana_program::system_program::id());
-    assert_eq!(proposal_account.data.len(), 0);
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+    assert_eq!(proposal_state.status, ProposalStatus::Cancelled);
 }

--- a/program/tests/create_proposal.rs
+++ b/program/tests/create_proposal.rs
@@ -3,7 +3,10 @@
 mod setup;
 
 use {
-    paladin_governance_program::{instruction::create_proposal, state::Proposal},
+    paladin_governance_program::{
+        instruction::create_proposal,
+        state::{Proposal, ProposalStatus},
+    },
     paladin_stake_program::state::Stake,
     setup::{setup, setup_proposal, setup_stake},
     solana_program_test::*,
@@ -286,7 +289,15 @@ async fn fail_proposal_already_initialized() {
     .await;
 
     // Set up an initialized proposal account.
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Draft,
+    )
+    .await;
 
     let instruction = create_proposal(&stake_authority.pubkey(), &stake, &proposal);
 

--- a/program/tests/finalize_proposal.rs
+++ b/program/tests/finalize_proposal.rs
@@ -1,0 +1,210 @@
+#![cfg(feature = "test-sbf")]
+
+mod setup;
+
+use {
+    paladin_governance_program::{
+        instruction::finalize_proposal,
+        state::{Proposal, ProposalStatus},
+    },
+    setup::{setup, setup_proposal},
+    solana_program_test::*,
+    solana_sdk::{
+        account::AccountSharedData,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+};
+
+#[tokio::test]
+async fn fail_stake_authority_not_signer() {
+    let stake_authority = Keypair::new();
+    let proposal = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+
+    let mut instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+    instruction.accounts[0].is_signer = false; // Stake authority not signer.
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer], // Stake authority not signer.
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+    );
+}
+
+#[tokio::test]
+async fn fail_proposal_incorrect_owner() {
+    let stake_authority = Keypair::new();
+    let proposal = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+
+    // Set up the proposal account with the incorrect owner.
+    {
+        let rent = context.banks_client.get_rent().await.unwrap();
+        let space = std::mem::size_of::<Proposal>();
+        let lamports = rent.minimum_balance(space);
+        context.set_account(
+            &proposal,
+            &AccountSharedData::new(lamports, space, &Pubkey::new_unique()), // Incorrect owner.
+        );
+    }
+
+    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+    );
+}
+
+#[tokio::test]
+async fn fail_proposal_not_initialized() {
+    let stake_authority = Keypair::new();
+    let proposal = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+
+    // Set up the proposal account uninitialized.
+    {
+        let rent = context.banks_client.get_rent().await.unwrap();
+        let space = std::mem::size_of::<Proposal>();
+        let lamports = rent.minimum_balance(space);
+        context.set_account(
+            &proposal,
+            &AccountSharedData::new(lamports, space, &paladin_governance_program::id()),
+        );
+    }
+
+    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::UninitializedAccount)
+    );
+}
+
+#[tokio::test]
+async fn fail_stake_authority_not_author() {
+    let stake_authority = Keypair::new();
+    let proposal = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &Pubkey::new_unique(), // Stake authority not author.
+        0,
+        0,
+        ProposalStatus::Draft,
+    )
+    .await;
+
+    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::IncorrectAuthority)
+    );
+}
+
+#[tokio::test]
+async fn success() {
+    let stake_authority = Keypair::new();
+    let proposal = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Draft,
+    )
+    .await;
+
+    let instruction = finalize_proposal(&stake_authority.pubkey(), &proposal);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Assert the proposal was marked with voting status.
+    let proposal_account = context
+        .banks_client
+        .get_account(proposal)
+        .await
+        .unwrap()
+        .unwrap();
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+    assert_eq!(proposal_state.status, ProposalStatus::Voting);
+}

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -199,7 +199,7 @@ async fn fail_proposal_not_initialized() {
 }
 
 #[tokio::test]
-async fn fail_proposal_not_accepted() {
+async fn fail_proposal_cooldown_in_progress() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
@@ -228,6 +228,62 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         ProposalStatus::Accepted,
+        NonZeroU64::new(clock.unix_timestamp as u64),
+    )
+    .await;
+
+    let instruction = process_proposal(&proposal, &governance);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinGovernanceError::ProposalNotAccepted as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_proposal_not_accepted() {
+    let proposal = Pubkey::new_unique();
+    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
+
+    let mut context = setup().start_with_context().await;
+
+    setup_governance(
+        &mut context,
+        &governance,
+        0,
+        0,
+        0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+    )
+    .await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+    setup_proposal_with_stake_and_cooldown(
+        &mut context,
+        &proposal,
+        &Pubkey::new_unique(),
+        0,
+        0,
+        0,
+        0,
+        0,
+        ProposalStatus::Voting, // Not accepted.
         NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -301,15 +301,15 @@ async fn success() {
         .await
         .unwrap();
 
-    // Assert the proposal was cleared and reassigned to the system program.
+    // Assert the proposal was marked with processed status.
     let proposal_account = context
         .banks_client
         .get_account(proposal)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(proposal_account.owner, solana_program::system_program::id());
-    assert_eq!(proposal_account.data.len(), 0);
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+    assert_eq!(proposal_state.status, ProposalStatus::Processed);
 
     // TODO: Assert the instruction was processed.
 }

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::process_proposal,
-        state::{Config, Proposal},
+        state::{Config, Proposal, ProposalStatus},
     },
     setup::{setup, setup_governance, setup_proposal_with_stake_and_cooldown},
     solana_program_test::*,
@@ -227,6 +227,7 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         0,
+        ProposalStatus::Accepted,
         NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
@@ -280,6 +281,7 @@ async fn success() {
         0,
         0,
         0,
+        ProposalStatus::Accepted,
         NonZeroU64::new(1),
     )
     .await;

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -2,7 +2,9 @@
 #![allow(dead_code)]
 
 use {
-    paladin_governance_program::state::{Config, Proposal, ProposalVote, ProposalVoteElection},
+    paladin_governance_program::state::{
+        Config, Proposal, ProposalStatus, ProposalVote, ProposalVoteElection,
+    },
     paladin_stake_program::state::{Config as StakeConfig, Stake},
     solana_program_test::*,
     solana_sdk::{
@@ -114,12 +116,14 @@ async fn _setup_proposal_inner(
     stake_for: u64,
     stake_against: u64,
     stake_abstained: u64,
+    status: ProposalStatus,
     cooldown: Option<NonZeroU64>,
 ) {
     let mut state = Proposal::new(author, creation_timestamp, instruction);
     state.stake_for = stake_for;
     state.stake_against = stake_against;
     state.stake_abstained = stake_abstained;
+    state.status = status;
 
     if cooldown.is_some() {
         state.cooldown_timestamp = cooldown;
@@ -151,6 +155,7 @@ pub async fn setup_proposal_with_stake_and_cooldown(
     stake_for: u64,
     stake_against: u64,
     stake_abstained: u64,
+    status: ProposalStatus,
     cooldown: Option<NonZeroU64>,
 ) {
     _setup_proposal_inner(
@@ -162,6 +167,7 @@ pub async fn setup_proposal_with_stake_and_cooldown(
         stake_for,
         stake_against,
         stake_abstained,
+        status,
         cooldown,
     )
     .await;
@@ -177,6 +183,7 @@ pub async fn setup_proposal_with_stake(
     stake_for: u64,
     stake_against: u64,
     stake_abstained: u64,
+    status: ProposalStatus,
 ) {
     _setup_proposal_inner(
         context,
@@ -187,6 +194,7 @@ pub async fn setup_proposal_with_stake(
         stake_for,
         stake_against,
         stake_abstained,
+        status,
         None,
     )
     .await;
@@ -198,6 +206,7 @@ pub async fn setup_proposal(
     author: &Pubkey,
     creation_timestamp: UnixTimestamp,
     instruction: u64,
+    status: ProposalStatus,
 ) {
     setup_proposal_with_stake(
         context,
@@ -208,6 +217,7 @@ pub async fn setup_proposal(
         0,
         0,
         0,
+        status,
     )
     .await;
 }

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -1469,6 +1469,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
         .await
         .unwrap()
         .unwrap();
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
 
     match expect {
         Expect::Cast {
@@ -1478,7 +1479,6 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             stake_abstained,
         } => {
             // Assert the proposal stake matches the expected values.
-            let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
             assert_eq!(proposal_state.stake_for, stake_for);
             assert_eq!(proposal_state.stake_against, stake_against);
             assert_eq!(proposal_state.stake_abstained, stake_abstained);
@@ -1492,10 +1492,8 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             }
         }
         Expect::Terminated => {
-            // Assert the proposal was terminated.
-            // The proposal should be cleared and reassigned to the system program.
-            assert_eq!(proposal_account.owner, solana_program::system_program::id());
-            assert_eq!(proposal_account.data.len(), 0);
+            // Assert the proposal was rejected.
+            assert_eq!(proposal_state.status, ProposalStatus::Rejected);
         }
     }
 }

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -6,8 +6,8 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         state::{
-            get_governance_address, get_proposal_vote_address, Config, Proposal, ProposalVote,
-            ProposalVoteElection,
+            get_governance_address, get_proposal_vote_address, Config, Proposal, ProposalStatus,
+            ProposalVote, ProposalVoteElection,
         },
     },
     paladin_stake_program::state::{find_stake_pda, Config as StakeConfig, Stake},
@@ -258,7 +258,15 @@ async fn fail_stake_config_incorrect_owner() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up a stake config account with an incorrect owner.
     {
@@ -322,7 +330,15 @@ async fn fail_stake_config_not_initialized() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up an uninitialized stake config account.
     {
@@ -387,7 +403,15 @@ async fn fail_governance_incorrect_address() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     let instruction = paladin_governance_program::instruction::switch_vote(
         &stake_authority.pubkey(),
@@ -682,6 +706,72 @@ async fn fail_proposal_not_initialized() {
 }
 
 #[tokio::test]
+async fn fail_proposal_not_voting() {
+    let stake_authority = Keypair::new();
+    let validator_vote = Pubkey::new_unique();
+    let stake_config = Pubkey::new_unique();
+    let proposal = Pubkey::new_unique();
+
+    let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
+    let proposal_vote =
+        get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
+
+    let mut context = setup().start_with_context().await;
+    setup_stake_config(&mut context, &stake_config, 0).await;
+    setup_stake(
+        &mut context,
+        &stake,
+        &stake_authority.pubkey(),
+        &validator_vote,
+        0,
+    )
+    .await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Draft, // Not in voting stage.
+    )
+    .await;
+
+    let instruction = paladin_governance_program::instruction::switch_vote(
+        &stake_authority.pubkey(),
+        &stake,
+        &stake_config,
+        &proposal_vote,
+        &proposal,
+        &governance,
+        ProposalVoteElection::For,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinGovernanceError::ProposalNotInVotingStage as u32)
+        )
+    );
+}
+
+#[tokio::test]
 async fn fail_proposal_vote_incorrect_address() {
     let stake_authority = Keypair::new();
     let validator_vote = Pubkey::new_unique();
@@ -703,7 +793,15 @@ async fn fail_proposal_vote_incorrect_address() {
     )
     .await;
     setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     let instruction = paladin_governance_program::instruction::switch_vote(
         &stake_authority.pubkey(),
@@ -761,7 +859,15 @@ async fn fail_proposal_vote_not_initialized() {
     )
     .await;
     setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up an uninitialized proposal vote account.
     {
@@ -1298,6 +1404,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             proposal_starting.stake_for,
             proposal_starting.stake_against,
             proposal_starting.stake_abstained,
+            ProposalStatus::Voting,
             NonZeroU64::new(1), // Doesn't matter, just has to be `Some`.
         )
         .await;
@@ -1311,6 +1418,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             proposal_starting.stake_for,
             proposal_starting.stake_against,
             proposal_starting.stake_abstained,
+            ProposalStatus::Voting,
         )
         .await;
     }

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::update_governance,
-        state::{Config, Proposal},
+        state::{Config, Proposal, ProposalStatus},
     },
     setup::{setup, setup_governance, setup_proposal_with_stake_and_cooldown},
     solana_program_test::*,
@@ -251,6 +251,7 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         0,
+        ProposalStatus::Accepted,
         NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
@@ -304,6 +305,7 @@ async fn success() {
         0,
         0,
         0,
+        ProposalStatus::Accepted,
         NonZeroU64::new(1),
     )
     .await;

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -6,8 +6,8 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         state::{
-            get_governance_address, get_proposal_vote_address, Config, Proposal, ProposalVote,
-            ProposalVoteElection,
+            get_governance_address, get_proposal_vote_address, Config, Proposal, ProposalStatus,
+            ProposalVote, ProposalVoteElection,
         },
     },
     paladin_stake_program::state::{find_stake_pda, Config as StakeConfig, Stake},
@@ -258,7 +258,15 @@ async fn fail_stake_config_incorrect_owner() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up a stake config account with an incorrect owner.
     {
@@ -322,7 +330,15 @@ async fn fail_stake_config_not_initialized() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up an uninitialized stake config account.
     {
@@ -387,7 +403,15 @@ async fn fail_governance_incorrect_address() {
         0,
     )
     .await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     let instruction = paladin_governance_program::instruction::vote(
         &stake_authority.pubkey(),
@@ -682,6 +706,72 @@ async fn fail_proposal_not_initialized() {
 }
 
 #[tokio::test]
+async fn fail_proposal_not_voting() {
+    let stake_authority = Keypair::new();
+    let validator_vote = Pubkey::new_unique();
+    let stake_config = Pubkey::new_unique();
+    let proposal = Pubkey::new_unique();
+
+    let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
+    let proposal_vote =
+        get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
+
+    let mut context = setup().start_with_context().await;
+    setup_stake_config(&mut context, &stake_config, 0).await;
+    setup_stake(
+        &mut context,
+        &stake,
+        &stake_authority.pubkey(),
+        &validator_vote,
+        0,
+    )
+    .await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Draft, // Not voting stage.
+    )
+    .await;
+
+    let instruction = paladin_governance_program::instruction::vote(
+        &stake_authority.pubkey(),
+        &stake,
+        &stake_config,
+        &proposal_vote,
+        &proposal,
+        &governance,
+        ProposalVoteElection::For,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinGovernanceError::ProposalNotInVotingStage as u32)
+        )
+    );
+}
+
+#[tokio::test]
 async fn fail_proposal_vote_incorrect_address() {
     let stake_authority = Keypair::new();
     let validator_vote = Pubkey::new_unique();
@@ -703,7 +793,15 @@ async fn fail_proposal_vote_incorrect_address() {
     )
     .await;
     setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     let instruction = paladin_governance_program::instruction::vote(
         &stake_authority.pubkey(),
@@ -761,7 +859,15 @@ async fn fail_proposal_vote_already_initialized() {
     )
     .await;
     setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
-    setup_proposal(&mut context, &proposal, &stake_authority.pubkey(), 0, 0).await;
+    setup_proposal(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        0,
+        0,
+        ProposalStatus::Voting,
+    )
+    .await;
 
     // Set up an initialized proposal vote account.
     setup_proposal_vote(
@@ -931,6 +1037,7 @@ async fn success(vote: Vote, expect: Expect) {
         PROPOSAL_STARTING_STAKE_FOR,
         PROPOSAL_STARTING_STAKE_AGAINST,
         PROPOSAL_STARTING_STAKE_ABSTAINED,
+        ProposalStatus::Voting,
     )
     .await;
 

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -1092,6 +1092,7 @@ async fn success(vote: Vote, expect: Expect) {
         .await
         .unwrap()
         .unwrap();
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
 
     match expect {
         Expect::Cast {
@@ -1101,7 +1102,6 @@ async fn success(vote: Vote, expect: Expect) {
             stake_abstained,
         } => {
             // Assert the proposal stake matches the expected values.
-            let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
             assert_eq!(proposal_state.stake_for, stake_for);
             assert_eq!(proposal_state.stake_against, stake_against);
             assert_eq!(proposal_state.stake_abstained, stake_abstained);
@@ -1115,10 +1115,8 @@ async fn success(vote: Vote, expect: Expect) {
             }
         }
         Expect::Terminated => {
-            // Assert the proposal was terminated.
-            // The proposal should be cleared and reassigned to the system program.
-            assert_eq!(proposal_account.owner, solana_program::system_program::id());
-            assert_eq!(proposal_account.data.len(), 0);
+            // Assert the proposal was rejected.
+            assert_eq!(proposal_state.status, ProposalStatus::Rejected);
         }
     }
 }


### PR DESCRIPTION
#### Problem
Currently, the governance program has no concept of "draft", "voting", and "accepted"
phases for proposals, amongst others. It also closes proposals, rather than marking them
"cancelled" or "rejected", and doesn't consider such a concept of stages when conducting
things like voting.

#### Summary of Changes
First introduce an enum for proposal state to track the proposal's current status.
Then, add checks for this status in the processor, flip the status rather than closing proposal
accounts, and finally add an instruction for users to finalize their draft proposals.