### PR TITLE
Vote timestamp & timings

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -622,16 +622,6 @@ fn process_switch_vote(
                 // This is done regardless of any cooldown period.
                 proposal_state.status = ProposalStatus::Rejected;
             }
-
-            if calculate_proposal_vote_threshold(proposal_state.stake_for, total_stake)?
-                < governance_config.proposal_acceptance_threshold
-                && proposal_state.cooldown_timestamp.is_some()
-            {
-                // If the proposal has fallen below the acceptance threshold, and
-                // it's currently in a cooldown period, terminate the cooldown
-                // period.
-                proposal_state.cooldown_timestamp = None;
-            }
         }
         ProposalVoteElection::DidNotVote => {
             // New vote is "did not vote". Increment stake abstained.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -338,7 +338,6 @@ fn process_vote(
     // If the proposal has an active cooldown period, ensure it has not ended.
     if proposal_state.cooldown_has_ended(governance_config.cooldown_period_seconds, &clock) {
         // If the cooldown period has ended, the proposal is accepted.
-        proposal_state.cooldown_timestamp = None;
         proposal_state.status = ProposalStatus::Accepted;
         return Ok(());
     }
@@ -503,7 +502,6 @@ fn process_switch_vote(
     // If the proposal has an active cooldown period, ensure it has not ended.
     if proposal_state.cooldown_has_ended(governance_config.cooldown_period_seconds, &clock) {
         // If the cooldown period has ended, the proposal is accepted.
-        proposal_state.cooldown_timestamp = None;
         proposal_state.status = ProposalStatus::Accepted;
         return Ok(());
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -645,6 +645,7 @@ fn process_initialize_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u32,
     proposal_rejection_threshold: u32,
+    voting_period_seconds: u64,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -697,6 +698,7 @@ fn process_initialize_governance(
                 proposal_rejection_threshold,
                 signer_bump_seed,
                 stake_config_info.key,
+                voting_period_seconds,
             );
     }
 
@@ -712,6 +714,7 @@ fn process_update_governance(
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u32,
     proposal_rejection_threshold: u32,
+    voting_period_seconds: u64,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -748,6 +751,7 @@ fn process_update_governance(
     state.cooldown_period_seconds = cooldown_period_seconds;
     state.proposal_acceptance_threshold = proposal_acceptance_threshold;
     state.proposal_rejection_threshold = proposal_rejection_threshold;
+    state.voting_period_seconds = voting_period_seconds;
 
     Ok(())
 }
@@ -785,6 +789,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
+            voting_period_seconds,
         } => {
             msg!("Instruction: InitializeGovernance");
             process_initialize_governance(
@@ -793,12 +798,14 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
+                voting_period_seconds,
             )
         }
         PaladinGovernanceInstruction::UpdateGovernance {
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
+            voting_period_seconds,
         } => {
             msg!("Instruction: UpdateGovernance");
             process_update_governance(
@@ -807,6 +814,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
                 cooldown_period_seconds,
                 proposal_acceptance_threshold,
                 proposal_rejection_threshold,
+                voting_period_seconds,
             )
         }
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -265,6 +265,10 @@ fn process_begin_voting(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     // Set the proposal's status to voting.
     proposal_state.status = ProposalStatus::Voting;
 
+    // Set the proposal's voting start timestamp.
+    let clock = <Clock as Sysvar>::get()?;
+    proposal_state.voting_start_timestamp = NonZeroU64::new(clock.unix_timestamp as u64);
+
     Ok(())
 }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -256,15 +256,27 @@ impl Proposal {
     }
 
     /// Evaluate the proposal cooldown period against the clock sysvar.
-    pub fn check_cooldown(&self, cooldown_period_seconds: u64, clock: &Clock) -> ProgramResult {
+    pub fn cooldown_has_ended(&self, cooldown_period_seconds: u64, clock: &Clock) -> bool {
         if let Some(cooldown_timestamp) = self.cooldown_timestamp {
             if (clock.unix_timestamp as u64).saturating_sub(cooldown_period_seconds)
                 >= cooldown_timestamp.get()
             {
-                return Ok(());
+                return true;
             }
         }
-        Err(PaladinGovernanceError::ProposalNotAccepted.into())
+        false
+    }
+
+    /// Evaluate the proposal voting period against the clock sysvar.
+    pub fn voting_has_ended(&self, voting_period_seconds: u64, clock: &Clock) -> bool {
+        if let Some(voting_start_timestamp) = self.voting_start_timestamp {
+            if (clock.unix_timestamp as u64).saturating_sub(voting_period_seconds)
+                >= voting_start_timestamp.get()
+            {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -141,10 +141,12 @@ pub struct Config {
     /// The signing bump seed, used to sign transactions for this governance
     /// config account with `invoke_signed`. Stored here to save on compute.
     pub signer_bump_seed: u8,
+    _padding: [u8; 7],
     /// The Paladin stake config account that this governance config account
     /// corresponds to.
     pub stake_config_address: Pubkey,
-    _padding: [u8; 7],
+    /// The voting period for proposals.
+    pub voting_period_seconds: u64,
 }
 
 impl Config {
@@ -155,14 +157,16 @@ impl Config {
         proposal_rejection_threshold: u32,
         signer_bump_seed: u8,
         stake_config_address: &Pubkey,
+        voting_period_seconds: u64,
     ) -> Self {
         Self {
             cooldown_period_seconds,
             proposal_acceptance_threshold,
             proposal_rejection_threshold,
             signer_bump_seed,
-            stake_config_address: *stake_config_address,
             _padding: [0; 7],
+            stake_config_address: *stake_config_address,
+            voting_period_seconds,
         }
     }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -221,6 +221,8 @@ pub struct Proposal {
     /// Proposal status
     pub status: ProposalStatus,
     _padding: [u8; 7],
+    /// The timestamp when voting began.
+    pub voting_start_timestamp: Option<NonZeroU64>,
 }
 
 impl Proposal {
@@ -236,6 +238,7 @@ impl Proposal {
             stake_against: 0,
             stake_for: 0,
             status: ProposalStatus::Draft,
+            voting_start_timestamp: None,
             _padding: [0; 7],
         }
     }

--- a/program/tests/initialize_governance.rs
+++ b/program/tests/initialize_governance.rs
@@ -45,6 +45,7 @@ async fn fail_stake_config_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -91,6 +92,7 @@ async fn fail_stake_config_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -127,6 +129,7 @@ async fn fail_governance_incorrect_address() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -163,7 +166,7 @@ async fn fail_governance_already_initialized() {
     setup_stake_config(&mut context, &stake_config, /* total_stake */ 100).await;
 
     // Set up an already initialized governance account.
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
 
     let instruction = initialize_governance(
         &governance,
@@ -171,6 +174,7 @@ async fn fail_governance_already_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -217,6 +221,7 @@ async fn success() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -113,6 +113,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        0,
     )
     .await;
 
@@ -162,6 +163,7 @@ async fn fail_proposal_not_initialized() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        0,
     )
     .await;
 
@@ -215,6 +217,7 @@ async fn fail_proposal_cooldown_in_progress() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        0,
     )
     .await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
@@ -271,6 +274,7 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        0,
     )
     .await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
@@ -326,6 +330,7 @@ async fn success() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        0,
     )
     .await;
     setup_proposal_with_stake_and_cooldown(

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -206,6 +206,7 @@ async fn fail_proposal_cooldown_in_progress() {
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     // Set up an unaccepted proposal.
     // Simply set the cooldown timestamp to the current clock timestamp,
@@ -220,7 +221,6 @@ async fn fail_proposal_cooldown_in_progress() {
         0,
     )
     .await;
-    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -231,7 +231,8 @@ async fn fail_proposal_cooldown_in_progress() {
         0,
         0,
         ProposalStatus::Accepted,
-        NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
 
@@ -266,6 +267,7 @@ async fn fail_proposal_not_accepted() {
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     setup_governance(
         &mut context,
@@ -277,7 +279,6 @@ async fn fail_proposal_not_accepted() {
         0,
     )
     .await;
-    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -288,7 +289,8 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         ProposalStatus::Voting, // Not accepted.
-        NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
 
@@ -323,6 +325,8 @@ async fn success() {
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
     setup_governance(
         &mut context,
         &governance,
@@ -343,7 +347,8 @@ async fn success() {
         0,
         0,
         ProposalStatus::Accepted,
-        NonZeroU64::new(1),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(1),
     )
     .await;
 

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -82,6 +82,7 @@ pub async fn setup_governance(
     proposal_acceptance_threshold: u32,
     proposal_rejection_threshold: u32,
     stake_config_address: &Pubkey,
+    voting_period_seconds: u64,
 ) {
     let state = Config::new(
         cooldown_period_seconds,
@@ -89,6 +90,7 @@ pub async fn setup_governance(
         proposal_rejection_threshold,
         /* signer_bump_seed */ 0, // TODO: Unused right now.
         stake_config_address,
+        voting_period_seconds,
     );
     let data = bytemuck::bytes_of(&state).to_vec();
 

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -119,17 +119,16 @@ async fn _setup_proposal_inner(
     stake_against: u64,
     stake_abstained: u64,
     status: ProposalStatus,
-    cooldown: Option<NonZeroU64>,
+    voting_start_timestamp: Option<NonZeroU64>,
+    cooldown_timestamp: Option<NonZeroU64>,
 ) {
     let mut state = Proposal::new(author, creation_timestamp, instruction);
+    state.cooldown_timestamp = cooldown_timestamp;
     state.stake_for = stake_for;
     state.stake_against = stake_against;
     state.stake_abstained = stake_abstained;
     state.status = status;
-
-    if cooldown.is_some() {
-        state.cooldown_timestamp = cooldown;
-    }
+    state.voting_start_timestamp = voting_start_timestamp;
 
     let data = bytemuck::bytes_of(&state).to_vec();
 
@@ -158,7 +157,8 @@ pub async fn setup_proposal_with_stake_and_cooldown(
     stake_against: u64,
     stake_abstained: u64,
     status: ProposalStatus,
-    cooldown: Option<NonZeroU64>,
+    voting_start_timestamp: Option<NonZeroU64>,
+    cooldown_timestamp: Option<NonZeroU64>,
 ) {
     _setup_proposal_inner(
         context,
@@ -170,7 +170,8 @@ pub async fn setup_proposal_with_stake_and_cooldown(
         stake_against,
         stake_abstained,
         status,
-        cooldown,
+        voting_start_timestamp,
+        cooldown_timestamp,
     )
     .await;
 }
@@ -186,6 +187,7 @@ pub async fn setup_proposal_with_stake(
     stake_against: u64,
     stake_abstained: u64,
     status: ProposalStatus,
+    voting_start_timestamp: Option<NonZeroU64>,
 ) {
     _setup_proposal_inner(
         context,
@@ -197,6 +199,7 @@ pub async fn setup_proposal_with_stake(
         stake_against,
         stake_abstained,
         status,
+        voting_start_timestamp,
         None,
     )
     .await;
@@ -220,6 +223,7 @@ pub async fn setup_proposal(
         0,
         0,
         status,
+        None,
     )
     .await;
 }

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -18,6 +18,7 @@ use {
     solana_program_test::*,
     solana_sdk::{
         account::AccountSharedData,
+        clock::Clock,
         instruction::InstructionError,
         pubkey::Pubkey,
         signature::Keypair,
@@ -1364,6 +1365,8 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
     let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
     setup_stake_config(&mut context, &stake_config, TOTAL_STAKE).await;
     setup_stake(
         &mut context,
@@ -1376,7 +1379,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
     setup_governance(
         &mut context,
         &governance,
-        /* cooldown_period_seconds */ 10, // Unused here.
+        /* cooldown_period_seconds */ 100_000,
         ACCEPTANCE_THRESHOLD,
         REJECTION_THRESHOLD,
         &stake_config,
@@ -1407,7 +1410,9 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             proposal_starting.stake_against,
             proposal_starting.stake_abstained,
             ProposalStatus::Voting,
-            NonZeroU64::new(1), // Doesn't matter, just has to be `Some`.
+            /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+            /* cooldown_timestamp */
+            NonZeroU64::new(clock.unix_timestamp.saturating_sub(100) as u64),
         )
         .await;
     } else {
@@ -1421,6 +1426,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             proposal_starting.stake_against,
             proposal_starting.stake_abstained,
             ProposalStatus::Voting,
+            /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
         )
         .await;
     }
@@ -1498,4 +1504,229 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
             assert_eq!(proposal_state.status, ProposalStatus::Rejected);
         }
     }
+}
+
+#[test_case(true)]
+#[test_case(false)]
+#[tokio::test]
+async fn success_voting_has_ended(was_accepted: bool) {
+    let stake_authority = Keypair::new();
+    let validator_vote = Pubkey::new_unique();
+    let stake_config = Pubkey::new_unique();
+    let proposal = Pubkey::new_unique();
+
+    let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
+    let proposal_vote =
+        get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
+
+    let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
+    setup_stake_config(&mut context, &stake_config, TOTAL_STAKE).await;
+    setup_stake(
+        &mut context,
+        &stake,
+        &stake_authority.pubkey(),
+        &validator_vote,
+        /* vote_stake */ 100_000,
+    )
+    .await;
+    setup_governance(
+        &mut context,
+        &governance,
+        /* cooldown_period_seconds */ 1_000, // Unused here.
+        ACCEPTANCE_THRESHOLD,
+        REJECTION_THRESHOLD,
+        &stake_config,
+        /* voting_period_seconds */ 10,
+    )
+    .await;
+
+    if was_accepted {
+        // Set up a proposal with a cooldown timestamp and stake for above
+        // threshold.
+        setup_proposal_with_stake_and_cooldown(
+            &mut context,
+            &proposal,
+            &stake_authority.pubkey(),
+            /* creation_timestamp */ 0,
+            /* instruction */ 0,
+            /* stake_for */ TOTAL_STAKE,
+            /* stake_against */ 0,
+            /* stake_abstained */ 0,
+            ProposalStatus::Voting,
+            /* voting_start_timestamp */
+            NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Now - 10 seconds.
+            /* cooldown_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        )
+        .await;
+    } else {
+        // Set up a proposal without a cooldown timestamp and stake against
+        // above threshold.
+        setup_proposal_with_stake(
+            &mut context,
+            &proposal,
+            &stake_authority.pubkey(),
+            /* creation_timestamp */ 0,
+            /* instruction */ 0,
+            /* stake_for */ 0,
+            /* stake_against */ TOTAL_STAKE,
+            /* stake_abstained */ 0,
+            ProposalStatus::Voting,
+            /* voting_start_timestamp */
+            NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Now - 10 seconds.
+        )
+        .await;
+    }
+
+    let instruction = paladin_governance_program::instruction::switch_vote(
+        &stake_authority.pubkey(),
+        &stake,
+        &stake_config,
+        &proposal_vote,
+        &proposal,
+        &governance,
+        ProposalVoteElection::For,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Assert the proposal vote was _not_ created.
+    assert!(context
+        .banks_client
+        .get_account(proposal_vote)
+        .await
+        .unwrap()
+        .is_none());
+
+    let proposal_account = context
+        .banks_client
+        .get_account(proposal)
+        .await
+        .unwrap()
+        .unwrap();
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+
+    // Assert there is no cooldown timestamp.
+    assert!(proposal_state.cooldown_timestamp.is_none());
+
+    if was_accepted {
+        // Assert the proposal was accepted.
+        assert_eq!(proposal_state.status, ProposalStatus::Accepted);
+    } else {
+        // Assert the proposal was rejected.
+        assert_eq!(proposal_state.status, ProposalStatus::Rejected);
+    }
+}
+
+#[tokio::test]
+async fn success_cooldown_has_ended() {
+    let stake_authority = Keypair::new();
+    let validator_vote = Pubkey::new_unique();
+    let stake_config = Pubkey::new_unique();
+    let proposal = Pubkey::new_unique();
+
+    let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
+    let proposal_vote =
+        get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
+
+    let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
+    setup_stake_config(&mut context, &stake_config, TOTAL_STAKE).await;
+    setup_stake(
+        &mut context,
+        &stake,
+        &stake_authority.pubkey(),
+        &validator_vote,
+        /* vote_stake */ 100_000,
+    )
+    .await;
+    setup_governance(
+        &mut context,
+        &governance,
+        /* cooldown_period_seconds */ 10,
+        ACCEPTANCE_THRESHOLD,
+        REJECTION_THRESHOLD,
+        &stake_config,
+        /* voting_period_seconds */ 1_000, // Unused here.
+    )
+    .await;
+
+    // Set up a proposal with a cooldown timestamp and stake for above
+    // threshold.
+    setup_proposal_with_stake_and_cooldown(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        /* creation_timestamp */ 0,
+        /* instruction */ 0,
+        /* stake_for */ TOTAL_STAKE,
+        /* stake_against */ 0,
+        /* stake_abstained */ 0,
+        ProposalStatus::Voting,
+        /* voting_start_timestamp */
+        NonZeroU64::new(clock.unix_timestamp as u64),
+        /* cooldown_timestamp */
+        NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Now - 10 seconds.
+    )
+    .await;
+
+    let instruction = paladin_governance_program::instruction::switch_vote(
+        &stake_authority.pubkey(),
+        &stake,
+        &stake_config,
+        &proposal_vote,
+        &proposal,
+        &governance,
+        ProposalVoteElection::For,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Assert the proposal vote was _not_ created.
+    assert!(context
+        .banks_client
+        .get_account(proposal_vote)
+        .await
+        .unwrap()
+        .is_none());
+
+    let proposal_account = context
+        .banks_client
+        .get_account(proposal)
+        .await
+        .unwrap()
+        .unwrap();
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+
+    // Assert there is no cooldown timestamp.
+    assert!(proposal_state.cooldown_timestamp.is_none());
+
+    // Assert the proposal was accepted.
+    assert_eq!(proposal_state.status, ProposalStatus::Accepted);
 }

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -1182,12 +1182,12 @@ enum Expect {
         new_election: ProposalVoteElection::Against,
     },
     Expect::Cast {
-        cooldown: false, // Cooldown reset.
+        cooldown: true, // Cooldown unchanged.
         stake_for: TOTAL_STAKE / 2 - TOTAL_STAKE / 10, // 40% of total stake.
         stake_against: TOTAL_STAKE / 4 + TOTAL_STAKE / 10, // 35% of total stake.
         stake_abstained: TOTAL_STAKE / 4, // Unchanged.
     };
-    "for_to_against_below_for_threshold_deducts_stake_for_increments_stake_against_rests_cooldown"
+    "for_to_against_below_for_threshold_deducts_stake_for_increments_stake_against"
 )]
 #[test_case(
     ProposalStarting {

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -597,7 +597,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -662,7 +662,7 @@ async fn fail_proposal_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
 
     // Set up the proposal account uninitialized.
     {
@@ -727,7 +727,7 @@ async fn fail_proposal_not_voting() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -792,7 +792,7 @@ async fn fail_proposal_vote_incorrect_address() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -858,7 +858,7 @@ async fn fail_proposal_vote_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -911,6 +911,7 @@ async fn fail_proposal_vote_not_initialized() {
 
 const ACCEPTANCE_THRESHOLD: u32 = 500_000_000; // 50%
 const REJECTION_THRESHOLD: u32 = 500_000_000; // 50%
+const VOTING_PERIOD_SECONDS: u64 = 100_000_000;
 const TOTAL_STAKE: u64 = 100_000_000;
 
 struct ProposalStarting {
@@ -1379,6 +1380,7 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
         ACCEPTANCE_THRESHOLD,
         REJECTION_THRESHOLD,
         &stake_config,
+        VOTING_PERIOD_SECONDS,
     )
     .await;
 

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -1841,9 +1841,6 @@ async fn success_cooldown_has_ended() {
         .unwrap();
     let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
 
-    // Assert there is no cooldown timestamp.
-    assert!(proposal_state.cooldown_timestamp.is_none());
-
     // Assert the proposal was accepted.
     assert_eq!(proposal_state.status, ProposalStatus::Accepted);
 

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -1506,10 +1506,8 @@ async fn success(proposal_starting: ProposalStarting, switch: VoteSwitch, expect
     }
 }
 
-#[test_case(true)]
-#[test_case(false)]
 #[tokio::test]
-async fn success_voting_has_ended(was_accepted: bool) {
+async fn success_voting_closed() {
     let stake_authority = Keypair::new();
     let validator_vote = Pubkey::new_unique();
     let stake_config = Pubkey::new_unique();
@@ -1520,8 +1518,13 @@ async fn success_voting_has_ended(was_accepted: bool) {
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
     let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
+    let prev_vote_stake = TOTAL_STAKE / 10;
+    let prev_election = ProposalVoteElection::Against;
+
+    let new_vote_stake = TOTAL_STAKE / 10 + 100;
+    let new_election = ProposalVoteElection::For;
+
     let mut context = setup().start_with_context().await;
-    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     setup_stake_config(&mut context, &stake_config, TOTAL_STAKE).await;
     setup_stake(
@@ -1529,13 +1532,13 @@ async fn success_voting_has_ended(was_accepted: bool) {
         &stake,
         &stake_authority.pubkey(),
         &validator_vote,
-        /* vote_stake */ 100_000,
+        new_vote_stake,
     )
     .await;
     setup_governance(
         &mut context,
         &governance,
-        /* cooldown_period_seconds */ 1_000, // Unused here.
+        /* cooldown_period_seconds */ 10,
         ACCEPTANCE_THRESHOLD,
         REJECTION_THRESHOLD,
         &stake_config,
@@ -1543,42 +1546,31 @@ async fn success_voting_has_ended(was_accepted: bool) {
     )
     .await;
 
-    if was_accepted {
-        // Set up a proposal with a cooldown timestamp and stake for above
-        // threshold.
-        setup_proposal_with_stake_and_cooldown(
-            &mut context,
-            &proposal,
-            &stake_authority.pubkey(),
-            /* creation_timestamp */ 0,
-            /* instruction */ 0,
-            /* stake_for */ TOTAL_STAKE,
-            /* stake_against */ 0,
-            /* stake_abstained */ 0,
-            ProposalStatus::Voting,
-            /* voting_start_timestamp */
-            NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Now - 10 seconds.
-            /* cooldown_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
-        )
-        .await;
-    } else {
-        // Set up a proposal without a cooldown timestamp and stake against
-        // above threshold.
-        setup_proposal_with_stake(
-            &mut context,
-            &proposal,
-            &stake_authority.pubkey(),
-            /* creation_timestamp */ 0,
-            /* instruction */ 0,
-            /* stake_for */ 0,
-            /* stake_against */ TOTAL_STAKE,
-            /* stake_abstained */ 0,
-            ProposalStatus::Voting,
-            /* voting_start_timestamp */
-            NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Now - 10 seconds.
-        )
-        .await;
-    }
+    // Set up a proposal with stake against > threshold and a voting period
+    // that began very long ago (expired).
+    setup_proposal_with_stake(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        /* creation_timestamp */ 0,
+        /* instruction */ 0,
+        /* stake_for */ 0,
+        /* stake_against */ TOTAL_STAKE,
+        /* stake_abstained */ 0,
+        ProposalStatus::Voting,
+        /* voting_start_timestamp */ NonZeroU64::new(1), // Wayyy earlier.
+    )
+    .await;
+
+    setup_proposal_vote(
+        &mut context,
+        &proposal_vote,
+        &proposal,
+        prev_vote_stake,
+        &stake_authority.pubkey(),
+        prev_election,
+    )
+    .await;
 
     let instruction = paladin_governance_program::instruction::switch_vote(
         &stake_authority.pubkey(),
@@ -1587,7 +1579,7 @@ async fn success_voting_has_ended(was_accepted: bool) {
         &proposal_vote,
         &proposal,
         &governance,
-        ProposalVoteElection::For,
+        new_election,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -1603,13 +1595,126 @@ async fn success_voting_has_ended(was_accepted: bool) {
         .await
         .unwrap();
 
-    // Assert the proposal vote was _not_ created.
-    assert!(context
+    let proposal_account = context
+        .banks_client
+        .get_account(proposal)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Assert the proposal was marked as rejected.
+    let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+    assert_eq!(proposal_state.status, ProposalStatus::Rejected);
+
+    let proposal_vote_account = context
         .banks_client
         .get_account(proposal_vote)
         .await
         .unwrap()
-        .is_none());
+        .unwrap();
+
+    // Assert the proposal vote was _not_ updated.
+    let proposal_vote_state = bytemuck::from_bytes::<ProposalVote>(&proposal_vote_account.data);
+    assert_eq!(proposal_vote_state.stake, prev_vote_stake);
+    assert_eq!(proposal_vote_state.election, prev_election);
+}
+
+#[tokio::test]
+async fn success_voting_closed_but_cooldown_active() {
+    // Here we're testing the case where a proposal's voting period has
+    // expired, but since there's an active cooldown period, it doesn'
+    // actually disable voting, and instead lets the cooldown period expire.
+    let stake_authority = Keypair::new();
+    let validator_vote = Pubkey::new_unique();
+    let stake_config = Pubkey::new_unique();
+    let proposal = Pubkey::new_unique();
+
+    let stake = find_stake_pda(&validator_vote, &stake_config, &paladin_stake_program::id()).0;
+    let proposal_vote =
+        get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
+    let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
+
+    let prev_vote_stake = TOTAL_STAKE / 10;
+    let prev_election = ProposalVoteElection::For;
+
+    let new_vote_stake = TOTAL_STAKE / 10 + 100;
+    let new_election = ProposalVoteElection::Against;
+
+    let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
+    setup_stake_config(&mut context, &stake_config, TOTAL_STAKE).await;
+    setup_stake(
+        &mut context,
+        &stake,
+        &stake_authority.pubkey(),
+        &validator_vote,
+        new_vote_stake,
+    )
+    .await;
+    setup_governance(
+        &mut context,
+        &governance,
+        /* cooldown_period_seconds */ 1_000,
+        ACCEPTANCE_THRESHOLD,
+        REJECTION_THRESHOLD,
+        &stake_config,
+        /* voting_period_seconds */ 10,
+    )
+    .await;
+
+    // Set up a proposal with stake for > threshold and an active cooldown
+    // period.
+    // The cooldown period is scheduled to expire _after_ the voting period
+    // expires.
+    setup_proposal_with_stake_and_cooldown(
+        &mut context,
+        &proposal,
+        &stake_authority.pubkey(),
+        /* creation_timestamp */ 0,
+        /* instruction */ 0,
+        /* stake_for */ TOTAL_STAKE,
+        /* stake_against */ 0,
+        /* stake_abstained */ 0,
+        ProposalStatus::Voting,
+        /* voting_start_timestamp */ NonZeroU64::new(1), // Wayyy earlier.
+        /* cooldown_timestamp */
+        NonZeroU64::new(clock.unix_timestamp.saturating_sub(10) as u64), // Still active.
+    )
+    .await;
+
+    setup_proposal_vote(
+        &mut context,
+        &proposal_vote,
+        &proposal,
+        prev_vote_stake,
+        &stake_authority.pubkey(),
+        prev_election,
+    )
+    .await;
+
+    let instruction = paladin_governance_program::instruction::switch_vote(
+        &stake_authority.pubkey(),
+        &stake,
+        &stake_config,
+        &proposal_vote,
+        &proposal,
+        &governance,
+        new_election,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
 
     let proposal_account = context
         .banks_client
@@ -1617,18 +1722,22 @@ async fn success_voting_has_ended(was_accepted: bool) {
         .await
         .unwrap()
         .unwrap();
+
+    // Assert the proposal is still in the voting stage.
     let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
+    assert_eq!(proposal_state.status, ProposalStatus::Voting);
 
-    // Assert there is no cooldown timestamp.
-    assert!(proposal_state.cooldown_timestamp.is_none());
+    let proposal_vote_account = context
+        .banks_client
+        .get_account(proposal_vote)
+        .await
+        .unwrap()
+        .unwrap();
 
-    if was_accepted {
-        // Assert the proposal was accepted.
-        assert_eq!(proposal_state.status, ProposalStatus::Accepted);
-    } else {
-        // Assert the proposal was rejected.
-        assert_eq!(proposal_state.status, ProposalStatus::Rejected);
-    }
+    // Assert the proposal vote was updated.
+    let proposal_vote_state = bytemuck::from_bytes::<ProposalVote>(&proposal_vote_account.data);
+    assert_eq!(proposal_vote_state.stake, new_vote_stake);
+    assert_eq!(proposal_vote_state.election, new_election);
 }
 
 #[tokio::test]
@@ -1643,6 +1752,12 @@ async fn success_cooldown_has_ended() {
         get_proposal_vote_address(&stake, &proposal, &paladin_governance_program::id());
     let governance = get_governance_address(&stake_config, &paladin_governance_program::id());
 
+    let prev_vote_stake = TOTAL_STAKE / 10;
+    let prev_election = ProposalVoteElection::Against;
+
+    let new_vote_stake = TOTAL_STAKE / 10 + 100;
+    let new_election = ProposalVoteElection::For;
+
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
@@ -1652,7 +1767,7 @@ async fn success_cooldown_has_ended() {
         &stake,
         &stake_authority.pubkey(),
         &validator_vote,
-        /* vote_stake */ 100_000,
+        new_vote_stake,
     )
     .await;
     setup_governance(
@@ -1662,7 +1777,7 @@ async fn success_cooldown_has_ended() {
         ACCEPTANCE_THRESHOLD,
         REJECTION_THRESHOLD,
         &stake_config,
-        /* voting_period_seconds */ 1_000, // Unused here.
+        /* voting_period_seconds */ 1_000,
     )
     .await;
 
@@ -1685,6 +1800,16 @@ async fn success_cooldown_has_ended() {
     )
     .await;
 
+    setup_proposal_vote(
+        &mut context,
+        &proposal_vote,
+        &proposal,
+        prev_vote_stake,
+        &stake_authority.pubkey(),
+        prev_election,
+    )
+    .await;
+
     let instruction = paladin_governance_program::instruction::switch_vote(
         &stake_authority.pubkey(),
         &stake,
@@ -1692,7 +1817,7 @@ async fn success_cooldown_has_ended() {
         &proposal_vote,
         &proposal,
         &governance,
-        ProposalVoteElection::For,
+        new_election,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -1708,14 +1833,6 @@ async fn success_cooldown_has_ended() {
         .await
         .unwrap();
 
-    // Assert the proposal vote was _not_ created.
-    assert!(context
-        .banks_client
-        .get_account(proposal_vote)
-        .await
-        .unwrap()
-        .is_none());
-
     let proposal_account = context
         .banks_client
         .get_account(proposal)
@@ -1729,4 +1846,16 @@ async fn success_cooldown_has_ended() {
 
     // Assert the proposal was accepted.
     assert_eq!(proposal_state.status, ProposalStatus::Accepted);
+
+    let proposal_vote_account = context
+        .banks_client
+        .get_account(proposal_vote)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Assert the proposal vote was _not_ updated.
+    let proposal_vote_state = bytemuck::from_bytes::<ProposalVote>(&proposal_vote_account.data);
+    assert_eq!(proposal_vote_state.stake, prev_vote_stake);
+    assert_eq!(proposal_vote_state.election, prev_election);
 }

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -45,6 +45,7 @@ async fn fail_governance_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -90,6 +91,7 @@ async fn fail_governance_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -125,6 +127,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(),
+        0,
     )
     .await;
 
@@ -145,6 +148,7 @@ async fn fail_proposal_incorrect_owner() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -180,6 +184,7 @@ async fn fail_proposal_not_initialized() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(),
+        0,
     )
     .await;
 
@@ -200,6 +205,7 @@ async fn fail_proposal_not_initialized() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -239,6 +245,7 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         /* stake_config_address */ &Pubkey::new_unique(),
+        0,
     )
     .await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
@@ -262,6 +269,7 @@ async fn fail_proposal_not_accepted() {
         /* cooldown_period_seconds */ 0,
         /* proposal_acceptance_threshold */ 0,
         /* proposal_rejection_threshold */ 0,
+        /* voting_period_seconds */ 0,
     );
 
     let transaction = Transaction::new_signed_with_payer(
@@ -295,7 +303,7 @@ async fn success() {
     let stake_config_address = Pubkey::new_unique();
 
     let mut context = setup().start_with_context().await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address, 0).await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -316,6 +324,7 @@ async fn success() {
         /* cooldown_period_seconds */ 1,
         /* proposal_acceptance_threshold */ 2,
         /* proposal_rejection_threshold */ 3,
+        /* voting_period_seconds */ 4,
     );
 
     let transaction = Transaction::new_signed_with_payer(

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -234,6 +234,7 @@ async fn fail_proposal_not_accepted() {
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     // Set up an unaccepted proposal.
     // Simply set the cooldown timestamp to the current clock timestamp,
@@ -248,7 +249,6 @@ async fn fail_proposal_not_accepted() {
         0,
     )
     .await;
-    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -259,7 +259,8 @@ async fn fail_proposal_not_accepted() {
         0,
         0,
         ProposalStatus::Accepted,
-        NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
 
@@ -303,6 +304,8 @@ async fn success() {
     let stake_config_address = Pubkey::new_unique();
 
     let mut context = setup().start_with_context().await;
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+
     setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address, 0).await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
@@ -314,7 +317,8 @@ async fn success() {
         0,
         0,
         ProposalStatus::Accepted,
-        NonZeroU64::new(1),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
+        /* voting_start_timestamp */ NonZeroU64::new(clock.unix_timestamp as u64),
     )
     .await;
 

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -1453,9 +1453,6 @@ async fn success_cooldown_has_ended() {
         .unwrap();
     let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
 
-    // Assert there is no cooldown timestamp.
-    assert!(proposal_state.cooldown_timestamp.is_none());
-
     // Assert the proposal was accepted.
     assert_eq!(proposal_state.status, ProposalStatus::Accepted);
 

--- a/program/tests/vote.rs
+++ b/program/tests/vote.rs
@@ -597,7 +597,7 @@ async fn fail_proposal_incorrect_owner() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -662,7 +662,7 @@ async fn fail_proposal_not_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
 
     // Set up the proposal account uninitialized.
     {
@@ -727,7 +727,7 @@ async fn fail_proposal_not_voting() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -792,7 +792,7 @@ async fn fail_proposal_vote_incorrect_address() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -858,7 +858,7 @@ async fn fail_proposal_vote_already_initialized() {
         0,
     )
     .await;
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config).await;
+    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config, 0).await;
     setup_proposal(
         &mut context,
         &proposal,
@@ -912,6 +912,7 @@ async fn fail_proposal_vote_already_initialized() {
 
 const ACCEPTANCE_THRESHOLD: u32 = 500_000_000; // 50%
 const REJECTION_THRESHOLD: u32 = 500_000_000; // 50%
+const VOTING_PERIOD_SECONDS: u64 = 100_000_000;
 const TOTAL_STAKE: u64 = 100_000_000;
 
 const PROPOSAL_STARTING_STAKE_FOR: u64 = 0;
@@ -1026,6 +1027,7 @@ async fn success(vote: Vote, expect: Expect) {
         ACCEPTANCE_THRESHOLD,
         REJECTION_THRESHOLD,
         &stake_config,
+        VOTING_PERIOD_SECONDS,
     )
     .await;
     setup_proposal_with_stake(


### PR DESCRIPTION
#### Problem
Currently, the governance program employs no concept of time or timestamps when
it comes to voting on proposals. At a minimum, it should support:

- The timestamp at which voting began.
- A specified voting time period.
- The closing of a voting period based on such timing.

#### Summary of Changes
Introduce support for all of the above!