### PR TITLE
Proposal governance config

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -63,7 +63,6 @@ pub enum PaladinGovernanceInstruction {
     /// 2. `[ ]` Paladin stake config account.
     /// 3. `[w]` Proposal vote account.
     /// 4. `[w]` Proposal account.
-    /// 5. `[ ]` Governance config account.
     /// 6. `[ ]` System program.
     Vote {
         /// Proposal vote election.
@@ -86,7 +85,6 @@ pub enum PaladinGovernanceInstruction {
     /// 2. `[ ]` Paladin stake config account.
     /// 3. `[w]` Proposal vote account.
     /// 4. `[w]` Proposal account.
-    /// 5. `[ ]` Governance config account.
     SwitchVote {
         /// New proposal vote election.
         new_election: ProposalVoteElection,
@@ -101,7 +99,6 @@ pub enum PaladinGovernanceInstruction {
     /// Accounts expected by this instruction:
     ///
     /// 0. `[w]` Proposal account.
-    /// 1. `[ ]` Governance config account.
     ProcessProposal,
     /// Initialize the governance config.
     ///
@@ -307,7 +304,6 @@ pub fn vote(
     stake_config_address: &Pubkey,
     proposal_vote_address: &Pubkey,
     proposal_address: &Pubkey,
-    governance_config_address: &Pubkey,
     election: ProposalVoteElection,
 ) -> Instruction {
     let accounts = vec![
@@ -316,7 +312,6 @@ pub fn vote(
         AccountMeta::new_readonly(*stake_config_address, false),
         AccountMeta::new(*proposal_vote_address, false),
         AccountMeta::new(*proposal_address, false),
-        AccountMeta::new_readonly(*governance_config_address, false),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
     let data = PaladinGovernanceInstruction::Vote { election }.pack();
@@ -332,7 +327,6 @@ pub fn switch_vote(
     stake_config_address: &Pubkey,
     proposal_vote_address: &Pubkey,
     proposal_address: &Pubkey,
-    governance_config_address: &Pubkey,
     new_election: ProposalVoteElection,
 ) -> Instruction {
     let accounts = vec![
@@ -341,7 +335,6 @@ pub fn switch_vote(
         AccountMeta::new_readonly(*stake_config_address, false),
         AccountMeta::new(*proposal_vote_address, false),
         AccountMeta::new(*proposal_address, false),
-        AccountMeta::new_readonly(*governance_config_address, false),
     ];
     let data = PaladinGovernanceInstruction::SwitchVote { new_election }.pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)
@@ -350,14 +343,8 @@ pub fn switch_vote(
 /// Creates a
 /// [ProcessProposal](enum.PaladinGovernanceInstruction.html)
 /// instruction.
-pub fn process_proposal(
-    proposal_address: &Pubkey,
-    governance_config_address: &Pubkey,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*proposal_address, false),
-        AccountMeta::new_readonly(*governance_config_address, false),
-    ];
+pub fn process_proposal(proposal_address: &Pubkey) -> Instruction {
+    let accounts = vec![AccountMeta::new(*proposal_address, false)];
     let data = PaladinGovernanceInstruction::ProcessProposal.pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -31,6 +31,7 @@ pub enum PaladinGovernanceInstruction {
     /// 0. `[s]` Paladin stake authority account.
     /// 1. `[ ]` Paladin stake account.
     /// 2. `[w]` Proposal account.
+    /// 3. `[ ]` Governance config account.
     CreateProposal,
     /// Cancel a governance proposal.
     ///
@@ -261,11 +262,13 @@ pub fn create_proposal(
     stake_authority_address: &Pubkey,
     stake_address: &Pubkey,
     proposal_address: &Pubkey,
+    governance_config_address: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new_readonly(*stake_authority_address, true),
         AccountMeta::new_readonly(*stake_address, false),
         AccountMeta::new(*proposal_address, false),
+        AccountMeta::new_readonly(*governance_config_address, false),
     ];
     let data = PaladinGovernanceInstruction::CreateProposal.pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -119,7 +119,7 @@ pub(crate) fn collect_proposal_vote_signer_seeds<'a>(
 }
 
 /// Governance configuration account.
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct Config {
     /// The cooldown period that begins when a proposal reaches the
@@ -214,6 +214,8 @@ pub struct Proposal {
     pub cooldown_timestamp: Option<NonZeroU64>,
     /// Timestamp for when proposal was created.
     pub creation_timestamp: UnixTimestamp,
+    /// The governance config for this proposal.
+    pub governance_config: Config,
     /// The instruction to execute, pending proposal acceptance.
     pub instruction: u64, // TODO: Replace with an actual serialized instruction?
     /// Amount of stake that did not vote.
@@ -231,12 +233,18 @@ pub struct Proposal {
 
 impl Proposal {
     /// Create a new [Proposal](struct.Proposal.html).
-    pub fn new(author: &Pubkey, creation_timestamp: UnixTimestamp, instruction: u64) -> Self {
+    pub fn new(
+        author: &Pubkey,
+        creation_timestamp: UnixTimestamp,
+        governance_config: Config,
+        instruction: u64,
+    ) -> Self {
         Self {
             discriminator: Self::SPL_DISCRIMINATOR.into(),
             author: *author,
             cooldown_timestamp: None,
             creation_timestamp,
+            governance_config,
             instruction,
             stake_abstained: 0,
             stake_against: 0,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -264,9 +264,10 @@ impl Proposal {
     }
 
     /// Evaluate the proposal cooldown period against the clock sysvar.
-    pub fn cooldown_has_ended(&self, cooldown_period_seconds: u64, clock: &Clock) -> bool {
+    pub fn cooldown_has_ended(&self, clock: &Clock) -> bool {
         if let Some(cooldown_timestamp) = self.cooldown_timestamp {
-            if (clock.unix_timestamp as u64).saturating_sub(cooldown_period_seconds)
+            if (clock.unix_timestamp as u64)
+                .saturating_sub(self.governance_config.cooldown_period_seconds)
                 >= cooldown_timestamp.get()
             {
                 return true;
@@ -276,9 +277,10 @@ impl Proposal {
     }
 
     /// Evaluate the proposal voting period against the clock sysvar.
-    pub fn voting_has_ended(&self, voting_period_seconds: u64, clock: &Clock) -> bool {
+    pub fn voting_has_ended(&self, clock: &Clock) -> bool {
         if let Some(voting_start_timestamp) = self.voting_start_timestamp {
-            if (clock.unix_timestamp as u64).saturating_sub(voting_period_seconds)
+            if (clock.unix_timestamp as u64)
+                .saturating_sub(self.governance_config.voting_period_seconds)
                 >= voting_start_timestamp.get()
             {
                 return true;

--- a/program/tests/begin_voting.rs
+++ b/program/tests/begin_voting.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::begin_voting,
-        state::{Proposal, ProposalStatus},
+        state::{Config, Proposal, ProposalStatus},
     },
     setup::{setup, setup_proposal},
     solana_program_test::*,
@@ -141,6 +141,7 @@ async fn fail_stake_authority_not_author() {
         &proposal,
         &Pubkey::new_unique(), // Stake authority not author.
         0,
+        Config::default(),
         0,
         ProposalStatus::Draft,
     )
@@ -179,6 +180,7 @@ async fn fail_proposal_not_in_draft_stage() {
         &proposal,
         &stake_authority.pubkey(),
         0,
+        Config::default(),
         0,
         ProposalStatus::Voting, // Not in draft stage.
     )
@@ -220,6 +222,7 @@ async fn success() {
         &proposal,
         &stake_authority.pubkey(),
         0,
+        Config::default(),
         0,
         ProposalStatus::Draft,
     )

--- a/program/tests/cancel_proposal.rs
+++ b/program/tests/cancel_proposal.rs
@@ -6,7 +6,7 @@ use {
     paladin_governance_program::{
         error::PaladinGovernanceError,
         instruction::cancel_proposal,
-        state::{Proposal, ProposalStatus},
+        state::{Config, Proposal, ProposalStatus},
     },
     setup::{setup, setup_proposal},
     solana_program_test::*,
@@ -141,6 +141,7 @@ async fn fail_stake_authority_not_author() {
         &proposal,
         &Pubkey::new_unique(), // Stake authority not author.
         0,
+        Config::default(),
         0,
         ProposalStatus::Draft,
     )
@@ -179,6 +180,7 @@ async fn fail_proposal_immutable() {
         &proposal,
         &stake_authority.pubkey(),
         0,
+        Config::default(),
         0,
         ProposalStatus::Accepted, // Proposal is immutable.
     )
@@ -220,6 +222,7 @@ async fn success() {
         &proposal,
         &stake_authority.pubkey(),
         0,
+        Config::default(),
         0,
         ProposalStatus::Draft,
     )

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -105,15 +105,24 @@ async fn fail_proposal_incorrect_owner() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 100_000_000,
+        /* proposal_acceptance_threshold */ 500_000_000, // 50%
+        /* proposal_rejection_threshold */ 500_000_000, // 50%
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        /* voting_period_seconds */ 100_000_000,
+    );
+
     let mut context = setup().start_with_context().await;
     setup_governance(
         &mut context,
         &governance,
-        0,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        0,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
     )
     .await;
 
@@ -155,15 +164,24 @@ async fn fail_proposal_not_initialized() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 100_000_000,
+        /* proposal_acceptance_threshold */ 500_000_000, // 50%
+        /* proposal_rejection_threshold */ 500_000_000, // 50%
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        /* voting_period_seconds */ 100_000_000,
+    );
+
     let mut context = setup().start_with_context().await;
     setup_governance(
         &mut context,
         &governance,
-        0,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        0,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
     )
     .await;
 
@@ -205,6 +223,15 @@ async fn fail_proposal_cooldown_in_progress() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 100_000_000,
+        /* proposal_acceptance_threshold */ 500_000_000, // 50%
+        /* proposal_rejection_threshold */ 500_000_000, // 50%
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        /* voting_period_seconds */ 100_000_000,
+    );
+
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
@@ -214,11 +241,11 @@ async fn fail_proposal_cooldown_in_progress() {
     setup_governance(
         &mut context,
         &governance,
-        1_000_000,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        0,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
     )
     .await;
     setup_proposal_with_stake_and_cooldown(
@@ -226,6 +253,7 @@ async fn fail_proposal_cooldown_in_progress() {
         &proposal,
         &Pubkey::new_unique(),
         0,
+        governance_config,
         0,
         0,
         0,
@@ -266,17 +294,26 @@ async fn fail_proposal_not_accepted() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 100_000_000,
+        /* proposal_acceptance_threshold */ 500_000_000, // 50%
+        /* proposal_rejection_threshold */ 500_000_000, // 50%
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        /* voting_period_seconds */ 100_000_000,
+    );
+
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     setup_governance(
         &mut context,
         &governance,
-        0,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        0,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
     )
     .await;
     setup_proposal_with_stake_and_cooldown(
@@ -284,6 +321,7 @@ async fn fail_proposal_not_accepted() {
         &proposal,
         &Pubkey::new_unique(),
         0,
+        governance_config,
         0,
         0,
         0,
@@ -324,17 +362,26 @@ async fn success() {
     let proposal = Pubkey::new_unique();
     let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 100_000_000,
+        /* proposal_acceptance_threshold */ 500_000_000, // 50%
+        /* proposal_rejection_threshold */ 500_000_000, // 50%
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
+        /* voting_period_seconds */ 100_000_000,
+    );
+
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
     setup_governance(
         &mut context,
         &governance,
-        0,
-        0,
-        0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        0,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
     )
     .await;
     setup_proposal_with_stake_and_cooldown(
@@ -342,6 +389,7 @@ async fn success() {
         &proposal,
         &Pubkey::new_unique(),
         0,
+        governance_config,
         0,
         0,
         0,

--- a/program/tests/process_proposal.rs
+++ b/program/tests/process_proposal.rs
@@ -8,7 +8,7 @@ use {
         instruction::process_proposal,
         state::{Config, Proposal, ProposalStatus},
     },
-    setup::{setup, setup_governance, setup_proposal_with_stake_and_cooldown},
+    setup::{setup, setup_proposal_with_stake_and_cooldown},
     solana_program_test::*,
     solana_sdk::{
         account::AccountSharedData,
@@ -22,109 +22,10 @@ use {
 };
 
 #[tokio::test]
-async fn fail_governance_incorrect_owner() {
-    let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
-
-    let mut context = setup().start_with_context().await;
-
-    // Set up the governance account with the incorrect owner.
-    {
-        let rent = context.banks_client.get_rent().await.unwrap();
-        let space = std::mem::size_of::<Config>();
-        let lamports = rent.minimum_balance(space);
-        context.set_account(
-            &governance,
-            &AccountSharedData::new(lamports, space, &Pubkey::new_unique()), // Incorrect owner.
-        );
-    }
-
-    let instruction = process_proposal(&proposal, &governance);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
-    );
-}
-
-#[tokio::test]
-async fn fail_governance_not_initialized() {
-    let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
-
-    let mut context = setup().start_with_context().await;
-
-    // Set up the governance account uninitialized.
-    {
-        let rent = context.banks_client.get_rent().await.unwrap();
-        let lamports = rent.minimum_balance(std::mem::size_of::<Config>());
-        context.set_account(
-            &governance,
-            &AccountSharedData::new(lamports, 0, &paladin_governance_program::id()),
-        );
-    }
-
-    let instruction = process_proposal(&proposal, &governance);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(0, InstructionError::UninitializedAccount)
-    );
-}
-
-#[tokio::test]
 async fn fail_proposal_incorrect_owner() {
     let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
-
-    let governance_config = Config::new(
-        /* cooldown_period_seconds */ 100_000_000,
-        /* proposal_acceptance_threshold */ 500_000_000, // 50%
-        /* proposal_rejection_threshold */ 500_000_000, // 50%
-        /* signer_bump_seed */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        /* voting_period_seconds */ 100_000_000,
-    );
 
     let mut context = setup().start_with_context().await;
-    setup_governance(
-        &mut context,
-        &governance,
-        governance_config.cooldown_period_seconds,
-        governance_config.proposal_acceptance_threshold,
-        governance_config.proposal_rejection_threshold,
-        &governance_config.stake_config_address,
-        governance_config.voting_period_seconds,
-    )
-    .await;
 
     // Set up the proposal account with the incorrect owner.
     {
@@ -137,7 +38,7 @@ async fn fail_proposal_incorrect_owner() {
         );
     }
 
-    let instruction = process_proposal(&proposal, &governance);
+    let instruction = process_proposal(&proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -162,28 +63,8 @@ async fn fail_proposal_incorrect_owner() {
 #[tokio::test]
 async fn fail_proposal_not_initialized() {
     let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
-
-    let governance_config = Config::new(
-        /* cooldown_period_seconds */ 100_000_000,
-        /* proposal_acceptance_threshold */ 500_000_000, // 50%
-        /* proposal_rejection_threshold */ 500_000_000, // 50%
-        /* signer_bump_seed */ 0,
-        /* stake_config_address */ &Pubkey::new_unique(), // Doesn't matter here.
-        /* voting_period_seconds */ 100_000_000,
-    );
 
     let mut context = setup().start_with_context().await;
-    setup_governance(
-        &mut context,
-        &governance,
-        governance_config.cooldown_period_seconds,
-        governance_config.proposal_acceptance_threshold,
-        governance_config.proposal_rejection_threshold,
-        &governance_config.stake_config_address,
-        governance_config.voting_period_seconds,
-    )
-    .await;
 
     // Set up the proposal account uninitialized.
     {
@@ -196,7 +77,7 @@ async fn fail_proposal_not_initialized() {
         );
     }
 
-    let instruction = process_proposal(&proposal, &governance);
+    let instruction = process_proposal(&proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -221,7 +102,6 @@ async fn fail_proposal_not_initialized() {
 #[tokio::test]
 async fn fail_proposal_cooldown_in_progress() {
     let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let governance_config = Config::new(
         /* cooldown_period_seconds */ 100_000_000,
@@ -238,16 +118,6 @@ async fn fail_proposal_cooldown_in_progress() {
     // Set up an unaccepted proposal.
     // Simply set the cooldown timestamp to the current clock timestamp,
     // and require more than 0 seconds for cooldown.
-    setup_governance(
-        &mut context,
-        &governance,
-        governance_config.cooldown_period_seconds,
-        governance_config.proposal_acceptance_threshold,
-        governance_config.proposal_rejection_threshold,
-        &governance_config.stake_config_address,
-        governance_config.voting_period_seconds,
-    )
-    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -264,7 +134,7 @@ async fn fail_proposal_cooldown_in_progress() {
     )
     .await;
 
-    let instruction = process_proposal(&proposal, &governance);
+    let instruction = process_proposal(&proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -292,7 +162,6 @@ async fn fail_proposal_cooldown_in_progress() {
 #[tokio::test]
 async fn fail_proposal_not_accepted() {
     let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let governance_config = Config::new(
         /* cooldown_period_seconds */ 100_000_000,
@@ -306,16 +175,6 @@ async fn fail_proposal_not_accepted() {
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
-    setup_governance(
-        &mut context,
-        &governance,
-        governance_config.cooldown_period_seconds,
-        governance_config.proposal_acceptance_threshold,
-        governance_config.proposal_rejection_threshold,
-        &governance_config.stake_config_address,
-        governance_config.voting_period_seconds,
-    )
-    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -332,7 +191,7 @@ async fn fail_proposal_not_accepted() {
     )
     .await;
 
-    let instruction = process_proposal(&proposal, &governance);
+    let instruction = process_proposal(&proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
@@ -360,7 +219,6 @@ async fn fail_proposal_not_accepted() {
 #[tokio::test]
 async fn success() {
     let proposal = Pubkey::new_unique();
-    let governance = Pubkey::new_unique(); // PDA doesn't matter here.
 
     let governance_config = Config::new(
         /* cooldown_period_seconds */ 100_000_000,
@@ -374,16 +232,6 @@ async fn success() {
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
-    setup_governance(
-        &mut context,
-        &governance,
-        governance_config.cooldown_period_seconds,
-        governance_config.proposal_acceptance_threshold,
-        governance_config.proposal_rejection_threshold,
-        &governance_config.stake_config_address,
-        governance_config.voting_period_seconds,
-    )
-    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
@@ -400,7 +248,7 @@ async fn success() {
     )
     .await;
 
-    let instruction = process_proposal(&proposal, &governance);
+    let instruction = process_proposal(&proposal);
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -114,6 +114,7 @@ async fn _setup_proposal_inner(
     proposal_address: &Pubkey,
     author: &Pubkey,
     creation_timestamp: UnixTimestamp,
+    governance_config: Config,
     instruction: u64,
     stake_for: u64,
     stake_against: u64,
@@ -122,7 +123,7 @@ async fn _setup_proposal_inner(
     voting_start_timestamp: Option<NonZeroU64>,
     cooldown_timestamp: Option<NonZeroU64>,
 ) {
-    let mut state = Proposal::new(author, creation_timestamp, instruction);
+    let mut state = Proposal::new(author, creation_timestamp, governance_config, instruction);
     state.cooldown_timestamp = cooldown_timestamp;
     state.stake_for = stake_for;
     state.stake_against = stake_against;
@@ -152,6 +153,7 @@ pub async fn setup_proposal_with_stake_and_cooldown(
     proposal_address: &Pubkey,
     author: &Pubkey,
     creation_timestamp: UnixTimestamp,
+    governance_config: Config,
     instruction: u64,
     stake_for: u64,
     stake_against: u64,
@@ -165,6 +167,7 @@ pub async fn setup_proposal_with_stake_and_cooldown(
         proposal_address,
         author,
         creation_timestamp,
+        governance_config,
         instruction,
         stake_for,
         stake_against,
@@ -182,6 +185,7 @@ pub async fn setup_proposal_with_stake(
     proposal_address: &Pubkey,
     author: &Pubkey,
     creation_timestamp: UnixTimestamp,
+    governance_config: Config,
     instruction: u64,
     stake_for: u64,
     stake_against: u64,
@@ -194,6 +198,7 @@ pub async fn setup_proposal_with_stake(
         proposal_address,
         author,
         creation_timestamp,
+        governance_config,
         instruction,
         stake_for,
         stake_against,
@@ -210,6 +215,7 @@ pub async fn setup_proposal(
     proposal_address: &Pubkey,
     author: &Pubkey,
     creation_timestamp: UnixTimestamp,
+    governance_config: Config,
     instruction: u64,
     status: ProposalStatus,
 ) {
@@ -218,6 +224,7 @@ pub async fn setup_proposal(
         proposal_address,
         author,
         creation_timestamp,
+        governance_config,
         instruction,
         0,
         0,

--- a/program/tests/update_governance.rs
+++ b/program/tests/update_governance.rs
@@ -254,6 +254,7 @@ async fn fail_proposal_not_accepted() {
         &proposal,
         &Pubkey::new_unique(),
         0,
+        Config::default(),
         0,
         0,
         0,
@@ -303,15 +304,34 @@ async fn success() {
 
     let stake_config_address = Pubkey::new_unique();
 
+    let governance_config = Config::new(
+        /* cooldown_period_seconds */ 0,
+        /* proposal_acceptance_threshold */ 0,
+        /* proposal_rejection_threshold */ 0,
+        /* signer_bump_seed */ 0,
+        /* stake_config_address */ &stake_config_address,
+        /* voting_period_seconds */ 0,
+    );
+
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
 
-    setup_governance(&mut context, &governance, 0, 0, 0, &stake_config_address, 0).await;
+    setup_governance(
+        &mut context,
+        &governance,
+        governance_config.cooldown_period_seconds,
+        governance_config.proposal_acceptance_threshold,
+        governance_config.proposal_rejection_threshold,
+        &governance_config.stake_config_address,
+        governance_config.voting_period_seconds,
+    )
+    .await;
     setup_proposal_with_stake_and_cooldown(
         &mut context,
         &proposal,
         &Pubkey::new_unique(),
         0,
+        governance_config,
         0,
         0,
         0,


### PR DESCRIPTION
This PR merely adds governance config to the proposal itself, and it's copied into
the proposal at time of creation. As a result, the governance config account is no
longer required for a few instructions.

We briefly discussed whether or not governance configs should be copied over
to a proposal at creation or finalization (begin voting) stage. I decided to go with
creation, since I felt like it made sense to ensure that once the governance config
is changed, only new proposals are directly affected.