### PR TITLE
Update governance behind accepted proposals

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -20,6 +20,9 @@ pub enum PaladinGovernanceError {
     /// Incorrect governance config address.
     #[error("Incorrect governance config address.")]
     IncorrectGovernanceConfigAddress,
+    /// Incorrect treasury address.
+    #[error("Incorrect treasury address.")]
+    IncorrectTreasuryAddress,
     /// Proposal not in voting stage.
     #[error("Proposal not in voting stage.")]
     ProposalNotInVotingStage,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -172,12 +172,13 @@ pub enum PaladinGovernanceInstruction {
     /// * The cooldown period for proposal execution.
     /// * Minimum required majority threshold.
     ///
-    /// This instruction can only be executed from an accepted proposal.
+    /// This instruction can only be executed from an accepted proposal, thus
+    /// it requires the PDA signature of the treasury.
     ///
     /// Accounts expected by this instruction:
     ///
+    /// 0. `[s]` Treasury account.
     /// 0. `[w]` Governance config account.
-    /// 1. `[ ]` Proposal account.
     UpdateGovernance {
         /// The cooldown period that begins when a proposal reaches the
         /// `proposal_acceptance_threshold` and upon its conclusion will execute
@@ -516,16 +517,16 @@ pub fn initialize_governance(
 /// [UpdateGovernance](enum.PaladinGovernanceInstruction.html)
 /// instruction.
 pub fn update_governance(
+    treasury_address: &Pubkey,
     governance_config_address: &Pubkey,
-    proposal_address: &Pubkey,
     cooldown_period_seconds: u64,
     proposal_acceptance_threshold: u32,
     proposal_rejection_threshold: u32,
     voting_period_seconds: u64,
 ) -> Instruction {
     let accounts = vec![
+        AccountMeta::new_readonly(*treasury_address, true),
         AccountMeta::new(*governance_config_address, false),
-        AccountMeta::new_readonly(*proposal_address, false),
     ];
     let data = PaladinGovernanceInstruction::UpdateGovernance {
         cooldown_period_seconds,


### PR DESCRIPTION
#### Problem
The last unfinished processor is for the `UpdateGovernance` instruction. This processor
should require that this instruction only be invoked by an accepted proposal.

As such, it should require the treasury PDA signature.

#### Summary of Changes
Rearchitect this processor to require the treasury PDA signature, then rewrite all of the
tests to use `ProcessInstruction` and an accepted proposal to invoke it.