### PR TITLE
Consider stake for in all vote-related processors

### DIFF
--- a/clients/js/src/generated/instructions/finishVoting.ts
+++ b/clients/js/src/generated/instructions/finishVoting.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/web3.js';
 import { PALADIN_GOVERNANCE_PROGRAM_ADDRESS } from '../programs';
@@ -29,6 +30,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export type FinishVotingInstruction<
   TProgram extends string = typeof PALADIN_GOVERNANCE_PROGRAM_ADDRESS,
   TAccountProposal extends string | IAccountMeta<string> = string,
+  TAccountStakeConfig extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -37,6 +39,9 @@ export type FinishVotingInstruction<
       TAccountProposal extends string
         ? WritableAccount<TAccountProposal>
         : TAccountProposal,
+      TAccountStakeConfig extends string
+        ? ReadonlyAccount<TAccountStakeConfig>
+        : TAccountStakeConfig,
       ...TRemainingAccounts,
     ]
   >;
@@ -66,16 +71,25 @@ export function getFinishVotingInstructionDataCodec(): Codec<
   );
 }
 
-export type FinishVotingInput<TAccountProposal extends string = string> = {
+export type FinishVotingInput<
+  TAccountProposal extends string = string,
+  TAccountStakeConfig extends string = string,
+> = {
   /** Proposal account */
   proposal: Address<TAccountProposal>;
+  /** Paladin stake config account */
+  stakeConfig: Address<TAccountStakeConfig>;
 };
 
-export function getFinishVotingInstruction<TAccountProposal extends string>(
-  input: FinishVotingInput<TAccountProposal>
+export function getFinishVotingInstruction<
+  TAccountProposal extends string,
+  TAccountStakeConfig extends string,
+>(
+  input: FinishVotingInput<TAccountProposal, TAccountStakeConfig>
 ): FinishVotingInstruction<
   typeof PALADIN_GOVERNANCE_PROGRAM_ADDRESS,
-  TAccountProposal
+  TAccountProposal,
+  TAccountStakeConfig
 > {
   // Program address.
   const programAddress = PALADIN_GOVERNANCE_PROGRAM_ADDRESS;
@@ -83,6 +97,7 @@ export function getFinishVotingInstruction<TAccountProposal extends string>(
   // Original accounts.
   const originalAccounts = {
     proposal: { value: input.proposal ?? null, isWritable: true },
+    stakeConfig: { value: input.stakeConfig ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
     keyof typeof originalAccounts,
@@ -91,12 +106,16 @@ export function getFinishVotingInstruction<TAccountProposal extends string>(
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {
-    accounts: [getAccountMeta(accounts.proposal)],
+    accounts: [
+      getAccountMeta(accounts.proposal),
+      getAccountMeta(accounts.stakeConfig),
+    ],
     programAddress,
     data: getFinishVotingInstructionDataEncoder().encode({}),
   } as FinishVotingInstruction<
     typeof PALADIN_GOVERNANCE_PROGRAM_ADDRESS,
-    TAccountProposal
+    TAccountProposal,
+    TAccountStakeConfig
   >;
 
   return instruction;
@@ -110,6 +129,8 @@ export type ParsedFinishVotingInstruction<
   accounts: {
     /** Proposal account */
     proposal: TAccountMetas[0];
+    /** Paladin stake config account */
+    stakeConfig: TAccountMetas[1];
   };
   data: FinishVotingInstructionData;
 };
@@ -122,7 +143,7 @@ export function parseFinishVotingInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedFinishVotingInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
+  if (instruction.accounts.length < 2) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -136,6 +157,7 @@ export function parseFinishVotingInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       proposal: getNextAccount(),
+      stakeConfig: getNextAccount(),
     },
     data: getFinishVotingInstructionDataDecoder().decode(instruction.data),
   };

--- a/program/idl.json
+++ b/program/idl.json
@@ -334,6 +334,14 @@
           "docs": [
             "Proposal account"
           ]
+        },
+        {
+          "name": "stakeConfig",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Paladin stake config account"
+          ]
         }
       ],
       "args": [],

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -287,11 +287,17 @@ pub enum PaladinGovernanceInstruction {
     /// Accounts expected by this instruction:
     /// 
     /// 0. `[w]` Proposal account.
+    /// 1. `[ ]` Paladin stake config account.
     #[account(
         0,
         writable,
         name = "proposal",
         description = "Proposal account"
+    )]
+    #[account(
+        1,
+        name = "stake_config",
+        description = "Paladin stake config account"
     )]
     FinishVoting,
     /// 
@@ -690,8 +696,11 @@ pub fn switch_vote(
 /// Creates a
 /// [FinishVoting](enum.PaladinGovernanceInstruction.html)
 /// instruction.
-pub fn finish_voting(proposal_address: &Pubkey) -> Instruction {
-    let accounts = vec![AccountMeta::new(*proposal_address, false)];
+pub fn finish_voting(proposal_address: &Pubkey, stake_config_address: &Pubkey) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*proposal_address, false),
+        AccountMeta::new_readonly(*stake_config_address, false),
+    ];
     let data = PaladinGovernanceInstruction::FinishVoting.pack();
     Instruction::new_with_bytes(crate::id(), &data, accounts)
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -829,12 +829,25 @@ fn process_finish_voting(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
     let accounts_iter = &mut accounts.iter();
 
     let proposal_info = next_account_info(accounts_iter)?;
+    let stake_config_info = next_account_info(accounts_iter)?;
+
+    check_stake_config_exists(stake_config_info)?;
+    let _total_stake =
+        bytemuck::try_from_bytes::<StakeConfig>(&stake_config_info.try_borrow_data()?)
+            .map_err(|_| ProgramError::InvalidAccountData)?
+            .token_amount_delegated;
 
     check_proposal_exists(program_id, proposal_info)?;
 
     let mut proposal_data = proposal_info.try_borrow_mut_data()?;
     let proposal_state = bytemuck::try_from_bytes_mut::<Proposal>(&mut proposal_data)
         .map_err(|_| ProgramError::InvalidAccountData)?;
+
+    let governance_config = proposal_state.governance_config;
+
+    // Ensure the address of the provided stake config account matches the one
+    // stored in the proposal's governance config.
+    governance_config.check_stake_config(stake_config_info.key)?;
 
     // Ensure the proposal is in the voting stage.
     if proposal_state.status != ProposalStatus::Voting {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -714,8 +714,18 @@ fn process_switch_vote(
 
     // If the proposal has an active cooldown period, ensure it has not ended.
     if proposal_state.cooldown_has_ended(&clock) {
-        // If the cooldown period has ended, the proposal is accepted.
-        proposal_state.status = ProposalStatus::Accepted;
+        // If the cooldown period has ended, the proposal is accepted
+        // only if it still meets the acceptance threshold.
+        // If not, the proposal is rejected.
+        if calculate_proposal_vote_threshold(proposal_state.stake_for, total_stake)?
+            >= proposal_state
+                .governance_config
+                .proposal_acceptance_threshold
+        {
+            proposal_state.status = ProposalStatus::Accepted;
+        } else {
+            proposal_state.status = ProposalStatus::Rejected;
+        }
         return Ok(());
     }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -556,8 +556,18 @@ fn process_vote(
 
     // If the proposal has an active cooldown period, ensure it has not ended.
     if proposal_state.cooldown_has_ended(&clock) {
-        // If the cooldown period has ended, the proposal is accepted.
-        proposal_state.status = ProposalStatus::Accepted;
+        // If the cooldown period has ended, the proposal is accepted
+        // only if it still meets the acceptance threshold.
+        // If not, the proposal is rejected.
+        if calculate_proposal_vote_threshold(proposal_state.stake_for, total_stake)?
+            >= proposal_state
+                .governance_config
+                .proposal_acceptance_threshold
+        {
+            proposal_state.status = ProposalStatus::Accepted;
+        } else {
+            proposal_state.status = ProposalStatus::Rejected;
+        }
         return Ok(());
     }
 

--- a/program/tests/switch_vote.rs
+++ b/program/tests/switch_vote.rs
@@ -1554,8 +1554,10 @@ async fn success_voting_closed_but_cooldown_active() {
     assert_eq!(proposal_vote_state.election, new_election);
 }
 
+#[test_case(true, ProposalStatus::Accepted; "threshold_met")]
+#[test_case(false, ProposalStatus::Rejected; "threshold_not_met")]
 #[tokio::test]
-async fn success_cooldown_has_ended() {
+async fn success_cooldown_has_ended(threshold_met: bool, expected_status: ProposalStatus) {
     let stake_authority = Keypair::new();
     let validator_vote = Pubkey::new_unique();
     let stake_config = Pubkey::new_unique();
@@ -1574,12 +1576,26 @@ async fn success_cooldown_has_ended() {
 
     let governance_config = GovernanceConfig::new(
         /* cooldown_period_seconds */ 10,
-        ACCEPTANCE_THRESHOLD,
+        ACCEPTANCE_THRESHOLD, // 50%
         REJECTION_THRESHOLD,
         /* signer_bump_seed */ 0,
         &stake_config,
         /* voting_period_seconds */ 1_000,
     );
+
+    // We'll set up a proposal whose cooldown period has ended.
+    // If `threshold_met` is true, the proposal's stake_for will be set to the
+    // exact amount needed to meet the threshold.
+    // If `threshold_met` is false, the proposal's stake_for will be set to
+    // just below the threshold.
+    // The vote doesn't matter, since once cooldown is over, no more votes can
+    // be tallied, so this invocation is basically just a crank.
+    let accepance_threshold_stake_amount = TOTAL_STAKE / 2; // 50%
+    let proposal_stake_for = if threshold_met {
+        accepance_threshold_stake_amount
+    } else {
+        accepance_threshold_stake_amount - 1
+    };
 
     let mut context = setup().start_with_context().await;
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
@@ -1602,7 +1618,7 @@ async fn success_cooldown_has_ended() {
         &stake_authority.pubkey(),
         /* creation_timestamp */ 0,
         governance_config,
-        /* stake_for */ TOTAL_STAKE,
+        proposal_stake_for,
         /* stake_against */ 0,
         /* stake_abstained */ 0,
         ProposalStatus::Voting,
@@ -1653,8 +1669,8 @@ async fn success_cooldown_has_ended() {
         .unwrap();
     let proposal_state = bytemuck::from_bytes::<Proposal>(&proposal_account.data);
 
-    // Assert the proposal was accepted.
-    assert_eq!(proposal_state.status, ProposalStatus::Accepted);
+    // Assert the proposal has the expected status.
+    assert_eq!(proposal_state.status, expected_status);
 
     let proposal_vote_account = context
         .banks_client


### PR DESCRIPTION
#### Problem
The governance program's voting mechanism uses a cooldown period to signal proposal acceptance. This cooldown period begins as soon as stake for reaches the acceptance threshold, and when it ends the proposal is accepted.

Currently, the only way for a proposal in cooldown mode to be rejected is to vote or switch enough votes to push stake against past the rejection threshold.

This results in a weird situation where stake for could reach the acceptance threshold, then many stakers switch their vote, resulting in a stake for much less than the acceptance threshold. This would still result in an accepted proposal.

#### Summary of Changes

As discussed in #24, simply adjust the cooldown checks in `Vote`, `SwitchVote`, and `FinishVoting` to only accept proposals whose cooldown period has ended _and_ whose stake for meets the acceptance threshold.

With this new implementation, if a cooldown period ends and the stake for is not greater than or equal to the acceptance threshold, the proposal is rejected.